### PR TITLE
feat: sub(#2) 打通钉钉真实回发闭环

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -13,7 +13,7 @@ config :men,
 
 config :men, Men.Gateway.DispatchServer,
   bridge_adapter: Men.RuntimeBridge.GongCLI,
-  egress_adapter: Men.Gateway.DispatchServer.NoopEgress,
+  egress_adapter: Men.Channels.Egress.RouterAdapter,
   storage_adapter: :memory
 
 config :men, Men.Channels.Ingress.FeishuAdapter,

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -33,6 +33,16 @@ config :men, :runtime_bridge,
   max_concurrency: parse_positive_integer_env.("RUNTIME_BRIDGE_MAX_CONCURRENCY", 10),
   backpressure_strategy: :reject
 
+# 钉钉机器人回发配置（生产可直接由环境变量驱动）。
+dingtalk_webhook_url = System.get_env("DINGTALK_ROBOT_WEBHOOK_URL")
+
+if is_binary(dingtalk_webhook_url) and dingtalk_webhook_url != "" do
+  config :men, Men.Channels.Egress.DingtalkRobotAdapter,
+    webhook_url: dingtalk_webhook_url,
+    secret: System.get_env("DINGTALK_ROBOT_SECRET"),
+    sign_enabled: System.get_env("DINGTALK_ROBOT_SIGN_ENABLED") in ~w(true TRUE 1)
+end
+
 # ## Using releases
 #
 # If you use `mix release`, you need to explicitly enable the server

--- a/lib/men/channels/egress/dingtalk_robot_adapter.ex
+++ b/lib/men/channels/egress/dingtalk_robot_adapter.ex
@@ -1,0 +1,136 @@
+defmodule Men.Channels.Egress.DingtalkRobotAdapter do
+  @moduledoc """
+  钉钉机器人出站适配：将最终消息主动发送到钉钉机器人 webhook。
+  """
+
+  @behaviour Men.Channels.Egress.Adapter
+
+  alias Men.Channels.Egress.Messages.{ErrorMessage, FinalMessage}
+
+  defmodule HttpTransport do
+    @moduledoc false
+
+    @callback post(binary(), [{binary(), binary()}], binary(), keyword()) ::
+                {:ok, %{status: non_neg_integer(), body: term()}} | {:error, term()}
+
+    @behaviour __MODULE__
+
+    @impl true
+    def post(url, headers, body, opts) do
+      finch_name = Keyword.get(opts, :finch, Men.Finch)
+      request = Finch.build(:post, url, headers, body)
+
+      case Finch.request(request, finch_name) do
+        {:ok, %Finch.Response{status: status, body: resp_body}} ->
+          decoded_body =
+            case Jason.decode(resp_body) do
+              {:ok, json} -> json
+              _ -> resp_body
+            end
+
+          {:ok, %{status: status, body: decoded_body}}
+
+        {:error, reason} ->
+          {:error, reason}
+      end
+    end
+  end
+
+  @impl true
+  def send(_target, %FinalMessage{} = message) do
+    send_text(build_final_text(message))
+  end
+
+  def send(_target, %ErrorMessage{} = message) do
+    send_text(build_error_text(message))
+  end
+
+  def send(_target, _message), do: {:error, :unsupported_message}
+
+  defp send_text(content) do
+    with {:ok, cfg} <- load_config(),
+         {:ok, url} <- build_url(cfg),
+         {:ok, body} <- Jason.encode(%{"msgtype" => "text", "text" => %{"content" => content}}),
+         :ok <- do_post(cfg, url, body) do
+      :ok
+    end
+  end
+
+  defp do_post(cfg, url, body) do
+    headers = [{"content-type", "application/json"}]
+
+    case cfg.transport.post(url, headers, body, cfg.request_opts) do
+      {:ok, %{status: 200, body: %{"errcode" => 0}}} ->
+        :ok
+
+      {:ok, %{status: 200, body: %{"errcode" => errcode, "errmsg" => errmsg}}} ->
+        {:error, {:dingtalk_error, errcode, errmsg}}
+
+      {:ok, %{status: status, body: body_resp}} ->
+        {:error, {:http_status, status, body_resp}}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp load_config do
+    app_cfg = Application.get_env(:men, __MODULE__, [])
+
+    webhook_url =
+      Keyword.get(app_cfg, :webhook_url) ||
+        System.get_env("DINGTALK_ROBOT_WEBHOOK_URL")
+
+    if is_binary(webhook_url) and webhook_url != "" do
+      {:ok,
+       %{
+         webhook_url: webhook_url,
+         secret: Keyword.get(app_cfg, :secret) || System.get_env("DINGTALK_ROBOT_SECRET"),
+         sign_enabled:
+           Keyword.get(app_cfg, :sign_enabled, false) or
+             System.get_env("DINGTALK_ROBOT_SIGN_ENABLED") in ~w(true TRUE 1),
+         transport: Keyword.get(app_cfg, :transport, HttpTransport),
+         request_opts: Keyword.get(app_cfg, :request_opts, [])
+       }}
+    else
+      {:error, :missing_webhook_url}
+    end
+  end
+
+  defp build_url(%{sign_enabled: true, secret: secret, webhook_url: url})
+       when is_binary(secret) and secret != "" do
+    timestamp = System.system_time(:millisecond)
+    string_to_sign = "#{timestamp}\n#{secret}"
+
+    sign =
+      :crypto.mac(:hmac, :sha256, secret, string_to_sign)
+      |> Base.encode64()
+
+    uri = URI.parse(url)
+    query = URI.decode_query(uri.query || "")
+    new_query = Map.merge(query, %{"timestamp" => Integer.to_string(timestamp), "sign" => sign})
+
+    {:ok, %{uri | query: URI.encode_query(new_query)} |> URI.to_string()}
+  end
+
+  defp build_url(%{webhook_url: url}), do: {:ok, url}
+
+  defp build_final_text(%FinalMessage{} = message) do
+    request_id = metadata_value(message.metadata, :request_id, "unknown_request")
+    run_id = metadata_value(message.metadata, :run_id, "unknown_run")
+    "[request_id=#{request_id} run_id=#{run_id}] #{message.content}"
+  end
+
+  defp build_error_text(%ErrorMessage{} = message) do
+    request_id = metadata_value(message.metadata, :request_id, "unknown_request")
+    run_id = metadata_value(message.metadata, :run_id, "unknown_run")
+    code = if is_binary(message.code) and message.code != "", do: "[#{message.code}] ", else: ""
+    "[request_id=#{request_id} run_id=#{run_id}] #{code}#{message.reason}"
+  end
+
+  defp metadata_value(metadata, key, default) when is_map(metadata) do
+    Map.get(metadata, key, Map.get(metadata, Atom.to_string(key), default))
+  end
+
+  defp metadata_value(_metadata, _key, default), do: default
+end

--- a/lib/men/channels/egress/router_adapter.ex
+++ b/lib/men/channels/egress/router_adapter.ex
@@ -1,0 +1,37 @@
+defmodule Men.Channels.Egress.RouterAdapter do
+  @moduledoc """
+  按 session_key 前缀路由到具体渠道 egress adapter。
+  """
+
+  @behaviour Men.Channels.Egress.Adapter
+
+  alias Men.Channels.Egress.{DingtalkRobotAdapter, FeishuAdapter}
+
+  @impl true
+  def send(target, message) do
+    case resolve_adapter(target) do
+      {:ok, adapter} -> adapter.send(target, message)
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp resolve_adapter(%{} = target) do
+    session_key =
+      Map.get(target, :session_key) ||
+        Map.get(target, "session_key") ||
+        Map.get(target, :target) ||
+        Map.get(target, "target")
+
+    resolve_adapter(session_key)
+  end
+
+  defp resolve_adapter(target) when is_binary(target) do
+    cond do
+      String.starts_with?(target, "feishu:") -> {:ok, FeishuAdapter}
+      String.starts_with?(target, "dingtalk:") -> {:ok, DingtalkRobotAdapter}
+      true -> {:error, :unsupported_channel}
+    end
+  end
+
+  defp resolve_adapter(_), do: {:error, :unsupported_channel}
+end

--- a/test/men/channels/egress/dingtalk_robot_adapter_test.exs
+++ b/test/men/channels/egress/dingtalk_robot_adapter_test.exs
@@ -1,0 +1,108 @@
+defmodule Men.Channels.Egress.DingtalkRobotAdapterTest do
+  use ExUnit.Case, async: true
+
+  alias Men.Channels.Egress.DingtalkRobotAdapter
+  alias Men.Channels.Egress.Messages.{ErrorMessage, FinalMessage}
+
+  defmodule MockTransport do
+    @behaviour Men.Channels.Egress.DingtalkRobotAdapter.HttpTransport
+
+    @impl true
+    def post(url, headers, body, _opts) do
+      if pid = Application.get_env(:men, :dingtalk_robot_test_pid) do
+        send(pid, {:transport_post, url, headers, body})
+      end
+
+      mode = Application.get_env(:men, :dingtalk_robot_test_mode, :ok)
+
+      case mode do
+        :ok ->
+          {:ok, %{status: 200, body: %{"errcode" => 0, "errmsg" => "ok"}}}
+
+        :dingtalk_error ->
+          {:ok, %{status: 200, body: %{"errcode" => 310_000, "errmsg" => "invalid user"}}}
+
+        :http_error ->
+          {:ok, %{status: 500, body: %{"error" => "server error"}}}
+
+        :network_error ->
+          {:error, :timeout}
+      end
+    end
+  end
+
+  setup do
+    Application.put_env(:men, :dingtalk_robot_test_pid, self())
+    Application.put_env(:men, :dingtalk_robot_test_mode, :ok)
+
+    Application.put_env(:men, DingtalkRobotAdapter,
+      webhook_url: "https://oapi.dingtalk.com/robot/send?access_token=test-token",
+      sign_enabled: false,
+      transport: MockTransport
+    )
+
+    on_exit(fn ->
+      Application.delete_env(:men, :dingtalk_robot_test_pid)
+      Application.delete_env(:men, :dingtalk_robot_test_mode)
+      Application.delete_env(:men, DingtalkRobotAdapter)
+    end)
+
+    :ok
+  end
+
+  test "发送 FinalMessage 成功" do
+    message = %FinalMessage{
+      session_key: "dingtalk:u1",
+      content: "done",
+      metadata: %{request_id: "req-1", run_id: "run-1"}
+    }
+
+    assert :ok = DingtalkRobotAdapter.send("dingtalk:u1", message)
+    assert_receive {:transport_post, url, headers, body}
+    assert String.contains?(url, "access_token=test-token")
+    assert {"content-type", "application/json"} in headers
+
+    decoded = Jason.decode!(body)
+    assert decoded["msgtype"] == "text"
+    assert String.contains?(decoded["text"]["content"], "request_id=req-1")
+    assert String.contains?(decoded["text"]["content"], "run_id=run-1")
+  end
+
+  test "发送 ErrorMessage 成功并带 code" do
+    message = %ErrorMessage{
+      session_key: "dingtalk:u1",
+      reason: "bridge failed",
+      code: "BRIDGE_FAIL",
+      metadata: %{request_id: "req-2", run_id: "run-2"}
+    }
+
+    assert :ok = DingtalkRobotAdapter.send("dingtalk:u1", message)
+    assert_receive {:transport_post, _url, _headers, body}
+    decoded = Jason.decode!(body)
+    assert String.contains?(decoded["text"]["content"], "[BRIDGE_FAIL]")
+  end
+
+  test "钉钉业务错误会返回标准错误" do
+    Application.put_env(:men, :dingtalk_robot_test_mode, :dingtalk_error)
+
+    message = %FinalMessage{session_key: "dingtalk:u1", content: "hello", metadata: %{}}
+
+    assert {:error, {:dingtalk_error, 310_000, "invalid user"}} =
+             DingtalkRobotAdapter.send("dingtalk:u1", message)
+  end
+
+  test "HTTP 错误会返回标准错误" do
+    Application.put_env(:men, :dingtalk_robot_test_mode, :http_error)
+
+    message = %FinalMessage{session_key: "dingtalk:u1", content: "hello", metadata: %{}}
+
+    assert {:error, {:http_status, 500, %{"error" => "server error"}}} =
+             DingtalkRobotAdapter.send("dingtalk:u1", message)
+  end
+
+  test "缺少 webhook_url 时返回错误" do
+    Application.put_env(:men, DingtalkRobotAdapter, transport: MockTransport, webhook_url: "")
+    message = %FinalMessage{session_key: "dingtalk:u1", content: "hello", metadata: %{}}
+    assert {:error, :missing_webhook_url} = DingtalkRobotAdapter.send("dingtalk:u1", message)
+  end
+end

--- a/test/men/channels/egress/router_adapter_test.exs
+++ b/test/men/channels/egress/router_adapter_test.exs
@@ -1,0 +1,11 @@
+defmodule Men.Channels.Egress.RouterAdapterTest do
+  use ExUnit.Case, async: true
+
+  alias Men.Channels.Egress.Messages.FinalMessage
+  alias Men.Channels.Egress.RouterAdapter
+
+  test "未知渠道返回错误" do
+    message = %FinalMessage{session_key: "unknown:u1", content: "hi", metadata: %{}}
+    assert {:error, :unsupported_channel} = RouterAdapter.send("unknown:u1", message)
+  end
+end


### PR DESCRIPTION
## Summary\n- 新增 DingtalkRobotAdapter，支持机器人 webhook 主动回发（可选签名）\n- 新增 RouterAdapter，按 session_key 前缀路由 egress 到 Feishu/DingTalk\n- DispatchServer 默认 egress 切换为 RouterAdapter\n- GongCLI 默认兼容 `gong run <prompt>` 位置参数模式，并保留旧 flag 模式兼容\n- 新增/扩展对应单测与回归测试\n\n## Test plan\n- MIX_ENV=test mix test test/men/runtime_bridge/gong_cli_test.exs test/men/channels/egress/dingtalk_robot_adapter_test.exs test/men/channels/egress/router_adapter_test.exs\n- MIX_ENV=test mix test test/men/gateway/dispatch_server_test.exs test/men_web/controllers/webhooks/dingtalk_controller_test.exs test/men_web/controllers/webhooks/feishu_controller_test.exs test/integration/dingtalk_webhook_flow_test.exs\n\nCloses #18