### PR TITLE
feat(ops): add internal ops-policy write/delete commands (#64)

### DIFF
--- a/lib/men/ops/policy/cache.ex
+++ b/lib/men/ops/policy/cache.ex
@@ -113,6 +113,18 @@ defmodule Men.Ops.Policy.Cache do
     :ok
   end
 
+  @spec delete(identity()) :: :ok | {:error, term()}
+  def delete(identity) do
+    with {:ok, key} <- normalize_identity(identity),
+         true <- ensure_tables() do
+      :ets.delete(@table, key)
+      :ok
+    else
+      {:error, reason} -> {:error, reason}
+      _ -> {:error, :cache_unavailable}
+    end
+  end
+
   @spec table_name() :: atom()
   def table_name, do: @table
 

--- a/lib/men/ops/policy/source.ex
+++ b/lib/men/ops/policy/source.ex
@@ -25,4 +25,5 @@ defmodule Men.Ops.Policy.Source do
   @callback get_version() :: {:ok, non_neg_integer()} | {:error, term()}
   @callback list_since_version(non_neg_integer()) :: {:ok, [policy_record()]} | {:error, term()}
   @callback upsert(identity(), map(), keyword()) :: {:ok, policy_record()} | {:error, term()}
+  @callback delete(identity(), keyword()) :: {:ok, policy_record()} | {:error, term()}
 end

--- a/lib/men/ops/policy/source/config.ex
+++ b/lib/men/ops/policy/source/config.ex
@@ -34,6 +34,9 @@ defmodule Men.Ops.Policy.Source.Config do
   @impl true
   def upsert(_identity, _value, _opts), do: {:error, :readonly_source}
 
+  @impl true
+  def delete(_identity, _opts), do: {:error, :readonly_source}
+
   defp do_fetch(identity) do
     policies = Application.get_env(:men, :ops_policy, []) |> Keyword.get(:default_policies, %{})
 

--- a/lib/men_web/internal_auth.ex
+++ b/lib/men_web/internal_auth.ex
@@ -1,0 +1,59 @@
+defmodule MenWeb.InternalAuth do
+  @moduledoc """
+  internal 接口统一 token 鉴权。
+  """
+
+  import Plug.Conn
+
+  @spec authorize(Plug.Conn.t(), keyword()) :: :ok | {:error, :missing_internal_token | :unauthorized}
+  def authorize(conn, opts \\ []) do
+    with {:ok, expected_token} <- fetch_expected_token(opts),
+         {:ok, presented_token} <- fetch_presented_token(conn),
+         true <- Plug.Crypto.secure_compare(expected_token, presented_token) do
+      :ok
+    else
+      {:error, reason} -> {:error, reason}
+      false -> {:error, :unauthorized}
+    end
+  end
+
+  defp fetch_expected_token(opts) do
+    config = Keyword.get(opts, :config, [])
+    env_keys = Keyword.get(opts, :env_keys, ["MEN_INTERNAL_TOKEN", "DINGTALK_STREAM_INTERNAL_TOKEN"])
+
+    config_token = Keyword.get(config, :internal_token)
+
+    env_token =
+      env_keys
+      |> Enum.find_value(fn key ->
+        value = System.get_env(key)
+        if is_binary(value) and value != "", do: value, else: nil
+      end)
+
+    token = config_token || env_token
+
+    if is_binary(token) and token != "" do
+      {:ok, token}
+    else
+      {:error, :missing_internal_token}
+    end
+  end
+
+  defp fetch_presented_token(conn) do
+    from_header = List.first(get_req_header(conn, "x-men-internal-token"))
+    token = from_header || bearer_token(conn)
+
+    if is_binary(token) and token != "" do
+      {:ok, token}
+    else
+      {:error, :unauthorized}
+    end
+  end
+
+  defp bearer_token(conn) do
+    case List.first(get_req_header(conn, "authorization")) do
+      "Bearer " <> token when is_binary(token) and token != "" -> token
+      _ -> nil
+    end
+  end
+end

--- a/lib/mix/tasks/men.ops_policy.delete.ex
+++ b/lib/mix/tasks/men.ops_policy.delete.ex
@@ -1,0 +1,52 @@
+defmodule Mix.Tasks.Men.OpsPolicy.Delete do
+  @moduledoc """
+  删除（软删除）一条 Ops Policy。
+  """
+
+  use Mix.Task
+
+  alias Men.Ops.Policy
+
+  @shortdoc "删除 Ops Policy"
+
+  @impl true
+  def run(args) do
+    Mix.Task.run("app.start")
+
+    with {:ok, identity, updated_by} <- parse_args(args),
+         {:ok, result} <- Policy.delete(identity, updated_by: updated_by) do
+      Mix.shell().info("status=ok")
+      Mix.shell().info("version=#{result.version}")
+      Mix.shell().info("source=#{result.source}")
+    else
+      {:error, reason} ->
+        Mix.raise("ops policy delete failed: #{inspect(reason)}")
+    end
+  end
+
+  defp parse_args(args) do
+    {opts, _, _} =
+      OptionParser.parse(args,
+        strict: [
+          tenant: :string,
+          env: :string,
+          scope: :string,
+          key: :string,
+          updated_by: :string
+        ]
+      )
+
+    identity = %{
+      tenant: opts[:tenant],
+      env: opts[:env],
+      scope: opts[:scope],
+      policy_key: opts[:key]
+    }
+
+    if Enum.all?(Map.values(identity), &(is_binary(&1) and String.trim(&1) != "")) do
+      {:ok, identity, opts[:updated_by] || "ops_cli"}
+    else
+      {:error, :missing_required_args}
+    end
+  end
+end

--- a/lib/mix/tasks/men.ops_policy.put.ex
+++ b/lib/mix/tasks/men.ops_policy.put.ex
@@ -1,0 +1,91 @@
+defmodule Mix.Tasks.Men.OpsPolicy.Put do
+  @moduledoc """
+  写入（upsert）一条 Ops Policy。
+  """
+
+  use Mix.Task
+
+  alias Men.Ops.Policy
+
+  @shortdoc "写入 Ops Policy"
+
+  @impl true
+  def run(args) do
+    Mix.Task.run("app.start")
+
+    with {:ok, identity, opts} <- parse_args(args),
+         {:ok, value} <- load_value(opts),
+         :ok <- validate_value(value),
+         {:ok, result} <- Policy.put(identity, value, updated_by: opts.updated_by) do
+      Mix.shell().info("status=ok")
+      Mix.shell().info("version=#{result.version}")
+      Mix.shell().info("source=#{result.source}")
+      Mix.shell().info("value=#{Jason.encode!(result.value)}")
+    else
+      {:error, reason} ->
+        Mix.raise("ops policy put failed: #{inspect(reason)}")
+    end
+  end
+
+  defp parse_args(args) do
+    {opts, _, _} =
+      OptionParser.parse(args,
+        strict: [
+          tenant: :string,
+          env: :string,
+          scope: :string,
+          key: :string,
+          value_json: :string,
+          value_file: :string,
+          updated_by: :string
+        ]
+      )
+
+    identity = %{
+      tenant: opts[:tenant],
+      env: opts[:env],
+      scope: opts[:scope],
+      policy_key: opts[:key]
+    }
+
+    if Enum.all?(Map.values(identity), &(is_binary(&1) and String.trim(&1) != "")) do
+      {:ok, identity,
+       %{
+         value_json: opts[:value_json],
+         value_file: opts[:value_file],
+         updated_by: opts[:updated_by] || "ops_cli"
+       }}
+    else
+      {:error, :missing_required_args}
+    end
+  end
+
+  defp load_value(%{value_file: path}) when is_binary(path) and path != "" do
+    with {:ok, content} <- File.read(path),
+         {:ok, value} <- Jason.decode(content) do
+      {:ok, value}
+    else
+      {:error, reason} -> {:error, {:invalid_value_file, reason}}
+    end
+  end
+
+  defp load_value(%{value_json: json}) when is_binary(json) and json != "" do
+    case Jason.decode(json) do
+      {:ok, value} -> {:ok, value}
+      {:error, reason} -> {:error, {:invalid_value_json, reason}}
+    end
+  end
+
+  defp load_value(_), do: {:error, :missing_value}
+
+  defp validate_value(%{
+         "acl" => acl,
+         "wake" => wake,
+         "dedup_ttl_ms" => dedup_ttl_ms
+       })
+       when is_map(acl) and is_map(wake) and is_integer(dedup_ttl_ms) and dedup_ttl_ms > 0 do
+    :ok
+  end
+
+  defp validate_value(_), do: {:error, :invalid_value_shape}
+end


### PR DESCRIPTION
## Summary
- 新增 `mix men.ops_policy.put` 与 `mix men.ops_policy.delete`，补齐配置中心策略写/删运维入口（保留现有 `get`）。
- 新增 `Men.Ops.Policy.delete/2`，并在 DB Source 增加软删除实现（`deleted_at` + 版本递增 + cache 清理 + 事件发布）。
- 补充 `Men.Ops.Policy.Source` delete callback 与测试覆盖。
- 统一 internal token 鉴权复用逻辑（`MenWeb.InternalAuth`），并接入现有 dingtalk stream internal controller。

## Test Plan
- `mix test test/men/ops/policy_test.exs test/men_web/controllers/internal/dingtalk_stream_controller_test.exs`
- 实测函数链路：`put -> get -> delete -> get`，删除后 DB active 行为 0。

Closes #64
