### PR TITLE
fix: 修复 #68 自审发现的 P1 语义问题

### DIFF
--- a/lib/men/gateway/event_envelope.ex
+++ b/lib/men/gateway/event_envelope.ex
@@ -76,7 +76,7 @@ defmodule Men.Gateway.EventEnvelope do
          {:ok, wake} <- fetch_optional_boolean(Map.get(normalized, "wake"), :wake),
          {:ok, inbox_only} <-
            fetch_optional_boolean(Map.get(normalized, "inbox_only"), :inbox_only),
-         {:ok, target} <- fetch_optional_text(Map.get(normalized, "target")),
+         {:ok, target} <- fetch_optional_text(Map.get(normalized, "target"), :target),
          {:ok, ts} <- fetch_timestamp(Map.get(normalized, "ts")),
          {:ok, meta} <- fetch_meta(Map.get(normalized, "meta")) do
       {:ok,
@@ -158,14 +158,14 @@ defmodule Men.Gateway.EventEnvelope do
     end
   end
 
-  defp fetch_optional_text(nil), do: {:ok, nil}
+  defp fetch_optional_text(nil, _field), do: {:ok, nil}
 
-  defp fetch_optional_text(value) when is_binary(value) do
+  defp fetch_optional_text(value, _field) when is_binary(value) do
     trimmed = String.trim(value)
     if trimmed == "", do: {:ok, nil}, else: {:ok, trimmed}
   end
 
-  defp fetch_optional_text(_), do: {:error, {:invalid_field, :target}}
+  defp fetch_optional_text(_, field), do: {:error, {:invalid_field, field}}
 
   defp fetch_version(nil), do: {:ok, 0}
   defp fetch_version(value) when is_integer(value) and value >= 0, do: {:ok, value}
@@ -220,8 +220,9 @@ defmodule Men.Gateway.EventEnvelope do
          :ok <- validate_task_transition(from_state, to_state),
          {:ok, occurred_at} <- fetch_occurred_at(normalized["occurred_at"]),
          {:ok, attempt} <- fetch_optional_positive_integer(normalized["attempt"], :attempt),
-         {:ok, reason_code} <- fetch_optional_text(normalized["reason_code"]),
-         {:ok, reason_message} <- fetch_optional_text(normalized["reason_message"]),
+         {:ok, reason_code} <- fetch_optional_text(normalized["reason_code"], :reason_code),
+         {:ok, reason_message} <-
+           fetch_optional_text(normalized["reason_message"], :reason_message),
          {:ok, idempotent_hit} <-
            fetch_optional_boolean(normalized["idempotent_hit"], :idempotent_hit) do
       payload =

--- a/test/men/gateway/event_envelope_test.exs
+++ b/test/men/gateway/event_envelope_test.exs
@@ -129,4 +129,38 @@ defmodule Men.Gateway.EventEnvelopeTest do
                }
              })
   end
+
+  test "任务状态事件 reason_code 非法类型返回 :reason_code" do
+    assert {:error, {:invalid_field, :reason_code}} =
+             EventEnvelope.normalize_task_state_event(%{
+               type: "task_state_changed",
+               source: "gateway.scheduler",
+               session_key: "scheduler:default",
+               event_id: "evt-task-reason-code-invalid",
+               payload: %{
+                 task_id: "task-1",
+                 from_state: "pending",
+                 to_state: "ready",
+                 occurred_at: "2026-02-25T03:42:00Z",
+                 reason_code: 123
+               }
+             })
+  end
+
+  test "任务状态事件 reason_message 非法类型返回 :reason_message" do
+    assert {:error, {:invalid_field, :reason_message}} =
+             EventEnvelope.normalize_task_state_event(%{
+               type: "task_state_changed",
+               source: "gateway.scheduler",
+               session_key: "scheduler:default",
+               event_id: "evt-task-reason-message-invalid",
+               payload: %{
+                 task_id: "task-1",
+                 from_state: "pending",
+                 to_state: "ready",
+                 occurred_at: "2026-02-25T03:42:00Z",
+                 reason_message: 123
+               }
+             })
+  end
 end

--- a/test/men/gateway/types_test.exs
+++ b/test/men/gateway/types_test.exs
@@ -62,6 +62,23 @@ defmodule Men.Gateway.TypesTest do
              })
   end
 
+  test "未命中幂等时返回 idempotent_hit=false" do
+    task = %{
+      task_id: "task-1",
+      schedule_type: :at,
+      max_retries: 2,
+      timeout_ms: 30_000
+    }
+
+    assert {:ok, %{idempotent_hit: false}} =
+             Types.resolve_idempotent_request(task, %{
+               task_id: "task-2",
+               schedule_type: :at,
+               max_retries: 2,
+               timeout_ms: 30_000
+             })
+  end
+
   test "超时与执行失败都可重试且重试耗尽后落 TASK_RETRY_EXHAUSTED" do
     assert Types.retryable_error_code?("TASK_TIMEOUT")
     assert Types.retryable_error_code?("TASK_EXECUTION_FAILED")


### PR DESCRIPTION
## Summary\n- 修复 ：未命中幂等时返回 ，仅命中时才做冲突检查\n- 修复  中  非法类型错误字段标注\n- 补充对应回归测试，覆盖未命中幂等和  非法类型边界\n\n## Test plan\n- Running ExUnit with seed: 402469, max_cases: 256

...
Finished in 0.07 seconds (0.07s async, 0.00s sync)
3 tests, 0 failures\n- Running ExUnit with seed: 100579, max_cases: 256

........................................................................15:22:11.090 [warning] acl_denied {"type":null,"key":"global.control.mode","source":null,"action":"write","role":"child","policy_version":"test-v1","session_key":"s1","event_id":"e1","inbox_only":false,"wake":false,"decision_reason":"acl_denied"}
15:22:11.090 [warning] acl_denied {"type":null,"key":"agent.agent_a.data.result","source":null,"action":"write","role":"tool","policy_version":"test-v1","session_key":"s1","event_id":null,"inbox_only":false,"wake":false,"decision_reason":"acl_denied"}
.15:22:11.091 [warning] acl_denied {"type":null,"key":"agent.agent_a.data.x","source":null,"action":"read","role":"tool","policy_version":"test-v1","session_key":"s1","event_id":"e2","inbox_only":false,"wake":false,"decision_reason":"acl_denied"}
.....................................15:22:11.397 request_id=req-deliver-fail [warning] dingtalk_card_egress.delta_fallback
....15:22:11.399 request_id=req-x [warning] dingtalk_card_egress.delta_fallback
........................15:22:12.301 [warning] gateway.ops_policy fallback reason={:policy_unavailable, {:db_error, %DBConnection.OwnershipError{message: "cannot find ownership process for #PID<0.1426.0> (:proc_lib)\nusing mode :manual.\n\nWhen using ownership, you must manage connections in one\nof the four ways:\n\n* By explicitly checking out a connection\n* By explicitly allowing a spawned process\n* By running the pool in shared mode\n* By using :caller option with allowed process\n\nThe first two options require every new process to explicitly\ncheck a connection out or be allowed by calling checkout or\nallow respectively.\n\nThe third option requires a {:shared, pid} mode to be set.\nIf using shared mode in tests, make sure your tests are not\nasync.\n\nThe fourth option requires [caller: pid] to be used when\nchecking out a connection from the pool. The caller process\nshould already be allowed on a connection.\n\nIf you are reading this error, it means you have not done one\nof the steps above or that the owner process has crashed.\n\nSee Ecto.Adapters.SQL.Sandbox docs for more information."}}, :not_found} policy_version=fallback
......15:22:13.221 [warning] gateway.ops_policy fallback reason={:policy_unavailable, {:db_error, %DBConnection.OwnershipError{message: "cannot find ownership process for #PID<0.1479.0> (:proc_lib)\nusing mode :manual.\n\nWhen using ownership, you must manage connections in one\nof the four ways:\n\n* By explicitly checking out a connection\n* By explicitly allowing a spawned process\n* By running the pool in shared mode\n* By using :caller option with allowed process\n\nThe first two options require every new process to explicitly\ncheck a connection out or be allowed by calling checkout or\nallow respectively.\n\nThe third option requires a {:shared, pid} mode to be set.\nIf using shared mode in tests, make sure your tests are not\nasync.\n\nThe fourth option requires [caller: pid] to be used when\nchecking out a connection from the pool. The caller process\nshould already be allowed on a connection.\n\nIf you are reading this error, it means you have not done one\nof the steps above or that the owner process has crashed.\n\nSee Ecto.Adapters.SQL.Sandbox docs for more information."}}, :not_found} policy_version=fallback
.......15:22:13.771 [warning] gateway.ops_policy fallback reason={:policy_unavailable, {:db_error, %DBConnection.OwnershipError{message: "cannot find ownership process for #PID<0.1518.0> (:proc_lib)\nusing mode :manual.\n\nWhen using ownership, you must manage connections in one\nof the four ways:\n\n* By explicitly checking out a connection\n* By explicitly allowing a spawned process\n* By running the pool in shared mode\n* By using :caller option with allowed process\n\nThe first two options require every new process to explicitly\ncheck a connection out or be allowed by calling checkout or\nallow respectively.\n\nThe third option requires a {:shared, pid} mode to be set.\nIf using shared mode in tests, make sure your tests are not\nasync.\n\nThe fourth option requires [caller: pid] to be used when\nchecking out a connection from the pool. The caller process\nshould already be allowed on a connection.\n\nIf you are reading this error, it means you have not done one\nof the steps above or that the owner process has crashed.\n\nSee Ecto.Adapters.SQL.Sandbox docs for more information."}}, :not_found} policy_version=fallback
15:22:13.772 [warning] acl_denied {"type":"tool_progress","key":"inbox.s1.E6","source":"tool.t1","action":"write","role":"tool","policy_version":"fallback","session_key":"s1","event_id":"E6","inbox_only":true,"wake":false,"decision_reason":"inbox_only"}
.15:22:13.876 [warning] gateway.ops_policy fallback reason={:policy_unavailable, {:db_error, %DBConnection.OwnershipError{message: "cannot find ownership process for #PID<0.1522.0> (:proc_lib)\nusing mode :manual.\n\nWhen using ownership, you must manage connections in one\nof the four ways:\n\n* By explicitly checking out a connection\n* By explicitly allowing a spawned process\n* By running the pool in shared mode\n* By using :caller option with allowed process\n\nThe first two options require every new process to explicitly\ncheck a connection out or be allowed by calling checkout or\nallow respectively.\n\nThe third option requires a {:shared, pid} mode to be set.\nIf using shared mode in tests, make sure your tests are not\nasync.\n\nThe fourth option requires [caller: pid] to be used when\nchecking out a connection from the pool. The caller process\nshould already be allowed on a connection.\n\nIf you are reading this error, it means you have not done one\nof the steps above or that the owner process has crashed.\n\nSee Ecto.Adapters.SQL.Sandbox docs for more information."}}, :not_found} policy_version=fallback
15:22:13.876 [warning] acl_denied {"type":"telemetry","key":"inbox.s1.E7","source":"external.partner","action":"write","role":"unknown","policy_version":"fallback","session_key":"s1","event_id":"E7","inbox_only":true,"wake":false,"decision_reason":"inbox_only"}
.15:22:13.980 [warning] gateway.ops_policy fallback reason={:policy_unavailable, {:db_error, %DBConnection.OwnershipError{message: "cannot find ownership process for #PID<0.1526.0> (:proc_lib)\nusing mode :manual.\n\nWhen using ownership, you must manage connections in one\nof the four ways:\n\n* By explicitly checking out a connection\n* By explicitly allowing a spawned process\n* By running the pool in shared mode\n* By using :caller option with allowed process\n\nThe first two options require every new process to explicitly\ncheck a connection out or be allowed by calling checkout or\nallow respectively.\n\nThe third option requires a {:shared, pid} mode to be set.\nIf using shared mode in tests, make sure your tests are not\nasync.\n\nThe fourth option requires [caller: pid] to be used when\nchecking out a connection from the pool. The caller process\nshould already be allowed on a connection.\n\nIf you are reading this error, it means you have not done one\nof the steps above or that the owner process has crashed.\n\nSee Ecto.Adapters.SQL.Sandbox docs for more information."}}, :not_found} policy_version=fallback
.15:22:13.983 [warning] gateway.ops_policy fallback reason={:policy_unavailable, {:db_error, %DBConnection.OwnershipError{message: "cannot find ownership process for #PID<0.1530.0> (:proc_lib)\nusing mode :manual.\n\nWhen using ownership, you must manage connections in one\nof the four ways:\n\n* By explicitly checking out a connection\n* By explicitly allowing a spawned process\n* By running the pool in shared mode\n* By using :caller option with allowed process\n\nThe first two options require every new process to explicitly\ncheck a connection out or be allowed by calling checkout or\nallow respectively.\n\nThe third option requires a {:shared, pid} mode to be set.\nIf using shared mode in tests, make sure your tests are not\nasync.\n\nThe fourth option requires [caller: pid] to be used when\nchecking out a connection from the pool. The caller process\nshould already be allowed on a connection.\n\nIf you are reading this error, it means you have not done one\nof the steps above or that the owner process has crashed.\n\nSee Ecto.Adapters.SQL.Sandbox docs for more information."}}, :not_found} policy_version=fallback
.15:22:14.088 [warning] gateway.ops_policy fallback reason={:policy_unavailable, {:db_error, %DBConnection.OwnershipError{message: "cannot find ownership process for #PID<0.1534.0> (:proc_lib)\nusing mode :manual.\n\nWhen using ownership, you must manage connections in one\nof the four ways:\n\n* By explicitly checking out a connection\n* By explicitly allowing a spawned process\n* By running the pool in shared mode\n* By using :caller option with allowed process\n\nThe first two options require every new process to explicitly\ncheck a connection out or be allowed by calling checkout or\nallow respectively.\n\nThe third option requires a {:shared, pid} mode to be set.\nIf using shared mode in tests, make sure your tests are not\nasync.\n\nThe fourth option requires [caller: pid] to be used when\nchecking out a connection from the pool. The caller process\nshould already be allowed on a connection.\n\nIf you are reading this error, it means you have not done one\nof the steps above or that the owner process has crashed.\n\nSee Ecto.Adapters.SQL.Sandbox docs for more information."}}, :not_found} policy_version=fallback
....15:22:14.409 [warning] gateway.ops_policy fallback reason={:policy_unavailable, {:db_error, %DBConnection.OwnershipError{message: "cannot find ownership process for #PID<0.1554.0> (:proc_lib)\nusing mode :manual.\n\nWhen using ownership, you must manage connections in one\nof the four ways:\n\n* By explicitly checking out a connection\n* By explicitly allowing a spawned process\n* By running the pool in shared mode\n* By using :caller option with allowed process\n\nThe first two options require every new process to explicitly\ncheck a connection out or be allowed by calling checkout or\nallow respectively.\n\nThe third option requires a {:shared, pid} mode to be set.\nIf using shared mode in tests, make sure your tests are not\nasync.\n\nThe fourth option requires [caller: pid] to be used when\nchecking out a connection from the pool. The caller process\nshould already be allowed on a connection.\n\nIf you are reading this error, it means you have not done one\nof the steps above or that the owner process has crashed.\n\nSee Ecto.Adapters.SQL.Sandbox docs for more information."}}, :not_found} policy_version=fallback
..........................................

  1) test push_receipt 缺失 run_id/action_id 应返回错误且不落库 (Men.Integration.AgentLoopReceiptFlowTest)
     test/integration/agent_loop_receipt_flow_test.exs:335
     ** (UndefinedFunctionError) function Men.Gateway.DispatchServer.push_receipt/2 is undefined or private
     code: DispatchServer.push_receipt(server, Map.delete(base, :run_id))
     stacktrace:
       (men 0.1.0) Men.Gateway.DispatchServer.push_receipt(#PID<0.1851.0>, %{code: "OK", data: %{}, message: "done", status: :ok, ts: 1772004135920, session_key: "feishu:u-invalid-receipt", retryable: false})
       test/integration/agent_loop_receipt_flow_test.exs:347: (test)



  2) test pending 按 run_id+action_id 隔离，ack 不应跨 run 误删 (Men.Integration.AgentLoopReceiptFlowTest)
     test/integration/agent_loop_receipt_flow_test.exs:277
     ** (UndefinedFunctionError) function Men.Gateway.DispatchServer.push_receipt/2 is undefined or private
     code: DispatchServer.push_receipt(server, %{
     stacktrace:
       (men 0.1.0) Men.Gateway.DispatchServer.push_receipt(#PID<0.1855.0>, %{code: "PERM_ACK", data: %{}, message: "manual-ack", status: :failed, ts: 1772004135939, session_key: "feishu:u-collision", run_id: "run-collision-1", retryable: false, action_id: "act-retry"})
       test/integration/agent_loop_receipt_flow_test.exs:298: (test)



  3) test 延迟回流: 回执晚到可被下一轮消费 (Men.Integration.AgentLoopReceiptFlowTest)
     test/integration/agent_loop_receipt_flow_test.exs:353
     ** (UndefinedFunctionError) function Men.Gateway.DispatchServer.push_receipt/2 is undefined or private
     code: assert {:ok, %{status: :stored}} = DispatchServer.push_receipt(server, attrs)
     stacktrace:
       (men 0.1.0) Men.Gateway.DispatchServer.push_receipt(#PID<0.1861.0>, %{code: "OK", data: %{late: true}, message: "late", status: :ok, ts: 1772004135946, session_key: "feishu:u-delay", run_id: "run-delay-1", retryable: false, action_id: "act-delay"})
       test/integration/agent_loop_receipt_flow_test.exs:375: (test)



  4) test 重复回执幂等: 同 run_id+action_id 不重复生效 (Men.Integration.AgentLoopReceiptFlowTest)
     test/integration/agent_loop_receipt_flow_test.exs:225
     ** (UndefinedFunctionError) function Men.Gateway.DispatchServer.push_receipt/2 is undefined or private
     code: assert {:ok, %{status: :stored}} = DispatchServer.push_receipt(server, attrs)
     stacktrace:
       (men 0.1.0) Men.Gateway.DispatchServer.push_receipt(#PID<0.1866.0>, %{code: "OK", data: %{}, message: "done", status: :ok, ts: 1772004135947, session_key: "feishu:u-idem", run_id: "run-idem-1", retryable: false, action_id: "act-idem"})
       test/integration/agent_loop_receipt_flow_test.exs:238: (test)



  5) test 成功动作: action->receipt 成功并回流下一轮 (Men.Integration.AgentLoopReceiptFlowTest)
     test/integration/agent_loop_receipt_flow_test.exs:132
     Assertion failed, no matching message after 100ms
     Showing 2 of 2 messages in the mailbox
     code: assert_receive {:gateway_event, %{type: "action_receipt", action_id: "act-success"}}
     mailbox:
       pattern: {:gateway_event, %{type: "action_receipt", action_id: "act-success"}}
       value:   {:bridge_prompt,
                 "{\"messages\":[{\"role\":\"user\",\"content\":\"hello\"}],\"scenario\":\"success_action\"}",
                 %{
                   request_id: "req-success-1",
                   session_key: "feishu:u-success",
                   run_id: "run-success-1",
                   external_session_key: "feishu:u-success"
                 }}

       pattern: {:gateway_event, %{type: "action_receipt", action_id: "act-success"}}
       value:   {:egress_called, "feishu:u-success",
                 %Men.Channels.Egress.Messages.FinalMessage{
                   session_key: "feishu:u-success",
                   content: "ok-success",
                   metadata: %{
                     request_id: "req-success-1",
                     session_key: "feishu:u-success",
                     run_id: "run-success-1",
                     jit_advisor_decision: :fixed_path,
                     jit_degraded: true,
                     jit_flag_state: :jit_enabled,
                     jit_rollback_reason: nil,
                     jit_snapshot_action: :fixed_path,
                     scenario: "success_action"
                   }
                 }}
     stacktrace:
       test/integration/agent_loop_receipt_flow_test.exs:142: (test)

.

  6) test 不可重试失败: retryable=false 且不中断主循环 (Men.Integration.AgentLoopReceiptFlowTest)
     test/integration/agent_loop_receipt_flow_test.exs:200
     Expected truthy, got false
     code: assert String.contains?(prompt, "\"action_id\":\"act-fail\"")
     arguments:

         # 1
         "{\"messages\":[{\"role\":\"user\",\"content\":\"next\"}],\"scenario\":\"no_action\"}"

         # 2
         "\"action_id\":\"act-fail\""

     stacktrace:
       test/integration/agent_loop_receipt_flow_test.exs:222: (test)



  7) test 可重试失败: retryable=true 且状态可观测 (Men.Integration.AgentLoopReceiptFlowTest)
     test/integration/agent_loop_receipt_flow_test.exs:172
     Assertion failed, no matching message after 100ms
     Showing 2 of 2 messages in the mailbox
     code: assert_receive {:gateway_event, %{type: "action_receipt", action_id: "act-retry", receipt: receipt}}
     mailbox:
       pattern: {:gateway_event, %{type: "action_receipt", action_id: "act-retry", receipt: receipt}}
       value:   {:bridge_prompt,
                 "{\"messages\":[{\"role\":\"user\",\"content\":\"retry\"}],\"scenario\":\"retryable_fail\"}",
                 %{
                   request_id: "req-retry-1",
                   session_key: "feishu:u-retry",
                   run_id: "run-retry-1",
                   external_session_key: "feishu:u-retry"
                 }}

       pattern: {:gateway_event, %{type: "action_receipt", action_id: "act-retry", receipt: receipt}}
       value:   {:egress_called, "feishu:u-retry",
                 %Men.Channels.Egress.Messages.FinalMessage{
                   session_key: "feishu:u-retry",
                   content: "ok-retry",
                   metadata: %{
                     request_id: "req-retry-1",
                     session_key: "feishu:u-retry",
                     run_id: "run-retry-1",
                     jit_advisor_decision: :fixed_path,
                     jit_degraded: true,
                     jit_flag_state: :jit_enabled,
                     jit_rollback_reason: nil,
                     jit_snapshot_action: :fixed_path,
                     scenario: "retryable_fail"
                   }
                 }}
     stacktrace:
       test/integration/agent_loop_receipt_flow_test.exs:183: (test)

15:22:16.174 [error] Task #PID<0.1897.0> started from #PID<0.1890.0> terminating
** (UndefinedFunctionError) function Men.Gateway.DispatchServer.push_receipt/2 is undefined or private
    (men 0.1.0) Men.Gateway.DispatchServer.push_receipt(#PID<0.1892.0>, %{code: "OK", data: %{}, message: "done", status: :ok, ts: 1772004136174, session_key: "feishu:u-idem-concurrent", run_id: "run-idem-concurrent-1", retryable: false, action_id: "act-idem-concurrent"})
    (elixir 1.17.3) lib/task/supervised.ex:101: Task.Supervised.invoke_mfa/2
    (elixir 1.17.3) lib/task/supervised.ex:36: Task.Supervised.reply/4
Function: &:erlang.apply/2
    Args: [#Function<8.38454437/1 in Men.Integration.AgentLoopReceiptFlowTest."test 并发重复回执幂等: 同 run_id+action_id 并发写入仅一次生效"/1>, [4]]
15:22:16.174 [error] Task #PID<0.1908.0> started from #PID<0.1890.0> terminating
** (UndefinedFunctionError) function Men.Gateway.DispatchServer.push_receipt/2 is undefined or private
    (men 0.1.0) Men.Gateway.DispatchServer.push_receipt(#PID<0.1892.0>, %{code: "OK", data: %{}, message: "done", status: :ok, ts: 1772004136174, session_key: "feishu:u-idem-concurrent", run_id: "run-idem-concurrent-1", retryable: false, action_id: "act-idem-concurrent"})
    (elixir 1.17.3) lib/task/supervised.ex:101: Task.Supervised.invoke_mfa/2
    (elixir 1.17.3) lib/task/supervised.ex:36: Task.Supervised.reply/4
Function: &:erlang.apply/2
    Args: [#Function<8.38454437/1 in Men.Integration.AgentLoopReceiptFlowTest."test 并发重复回执幂等: 同 run_id+action_id 并发写入仅一次生效"/1>, [15]]
15:22:16.174 [error] Task #PID<0.1895.0> started from #PID<0.1890.0> terminating
** (UndefinedFunctionError) function Men.Gateway.DispatchServer.push_receipt/2 is undefined or private
    (men 0.1.0) Men.Gateway.DispatchServer.push_receipt(#PID<0.1892.0>, %{code: "OK", data: %{}, message: "done", status: :ok, ts: 1772004136174, session_key: "feishu:u-idem-concurrent", run_id: "run-idem-concurrent-1", retryable: false, action_id: "act-idem-concurrent"})
    (elixir 1.17.3) lib/task/supervised.ex:101: Task.Supervised.invoke_mfa/2
    (elixir 1.17.3) lib/task/supervised.ex:36: Task.Supervised.reply/4
Function: &:erlang.apply/2
    Args: [#Function<8.38454437/1 in Men.Integration.AgentLoopReceiptFlowTest."test 并发重复回执幂等: 同 run_id+action_id 并发写入仅一次生效"/1>, [2]]
15:22:16.174 [error] Task #PID<0.1903.0> started from #PID<0.1890.0> terminating
** (UndefinedFunctionError) function Men.Gateway.DispatchServer.push_receipt/2 is undefined or private
    (men 0.1.0) Men.Gateway.DispatchServer.push_receipt(#PID<0.1892.0>, %{code: "OK", data: %{}, message: "done", status: :ok, ts: 1772004136174, session_key: "feishu:u-idem-concurrent", run_id: "run-idem-concurrent-1", retryable: false, action_id: "act-idem-concurrent"})
    (elixir 1.17.3) lib/task/supervised.ex:101: Task.Supervised.invoke_mfa/2
    (elixir 1.17.3) lib/task/supervised.ex:36: Task.Supervised.reply/4
Function: &:erlang.apply/2
    Args: [#Function<8.38454437/1 in Men.Integration.AgentLoopReceiptFlowTest."test 并发重复回执幂等: 同 run_id+action_id 并发写入仅一次生效"/1>, ~c"\n"]
15:22:16.174 [error] Task #PID<0.1912.0> started from #PID<0.1890.0> terminating
** (UndefinedFunctionError) function Men.Gateway.DispatchServer.push_receipt/2 is undefined or private
    (men 0.1.0) Men.Gateway.DispatchServer.push_receipt(#PID<0.1892.0>, %{code: "OK", data: %{}, message: "done", status: :ok, ts: 1772004136174, session_key: "feishu:u-idem-concurrent", run_id: "run-idem-concurrent-1", retryable: false, action_id: "act-idem-concurrent"})
    (elixir 1.17.3) lib/task/supervised.ex:101: Task.Supervised.invoke_mfa/2
    (elixir 1.17.3) lib/task/supervised.ex:36: Task.Supervised.reply/4
Function: &:erlang.apply/2
    Args: [#Function<8.38454437/1 in Men.Integration.AgentLoopReceiptFlowTest."test 并发重复回执幂等: 同 run_id+action_id 并发写入仅一次生效"/1>, [19]]
15:22:16.192 [error] GenServer #PID<0.1891.0> terminating
** (UndefinedFunctionError) function Men.Gateway.DispatchServer.push_receipt/2 is undefined or private
    (men 0.1.0) Men.Gateway.DispatchServer.push_receipt(#PID<0.1892.0>, %{code: "OK", data: %{}, message: "done", status: :ok, ts: 1772004136174, session_key: "feishu:u-idem-concurrent", run_id: "run-idem-concurrent-1", retryable: false, action_id: "act-idem-concurrent"})
    (elixir 1.17.3) lib/task/supervised.ex:101: Task.Supervised.invoke_mfa/2
    (elixir 1.17.3) lib/task/supervised.ex:36: Task.Supervised.reply/4
Last message: {:EXIT, #PID<0.1890.0>, {:undef, [{Men.Gateway.DispatchServer, :push_receipt, [#PID<0.1892.0>, %{code: "OK", data: %{}, message: "done", status: :ok, ts: 1772004136174, session_key: "feishu:u-idem-concurrent", run_id: "run-idem-concurrent-1", retryable: false, action_id: "act-idem-concurrent"}], []}, {Task.Supervised, :invoke_mfa, 2, [file: ~c"lib/task/supervised.ex", line: 101]}, {Task.Supervised, :reply, 4, [file: ~c"lib/task/supervised.ex", line: 36]}]}}


  8) test 并发重复回执幂等: 同 run_id+action_id 并发写入仅一次生效 (Men.Integration.AgentLoopReceiptFlowTest)
     test/integration/agent_loop_receipt_flow_test.exs:245
     ** (EXIT from #PID<0.1890.0>) an exception was raised:
         ** (UndefinedFunctionError) function Men.Gateway.DispatchServer.push_receipt/2 is undefined or private
             (men 0.1.0) Men.Gateway.DispatchServer.push_receipt(#PID<0.1892.0>, %{code: "OK", data: %{}, message: "done", status: :ok, ts: 1772004136174, session_key: "feishu:u-idem-concurrent", run_id: "run-idem-concurrent-1", retryable: false, action_id: "act-idem-concurrent"})
             (elixir 1.17.3) lib/task/supervised.ex:101: Task.Supervised.invoke_mfa/2
             (elixir 1.17.3) lib/task/supervised.ex:36: Task.Supervised.reply/4

....................................................................................15:22:22.075 [warning] gateway.ops_policy fallback reason=:invalid_identity policy_version=fallback
.15:22:22.077 [warning] gateway.ops_policy fallback reason={:policy_unavailable, {:db_error, %DBConnection.OwnershipError{message: "cannot find ownership process for #PID<0.2363.0> (:erlang)\nusing mode :manual.\n\nWhen using ownership, you must manage connections in one\nof the four ways:\n\n* By explicitly checking out a connection\n* By explicitly allowing a spawned process\n* By running the pool in shared mode\n* By using :caller option with allowed process\n\nThe first two options require every new process to explicitly\ncheck a connection out or be allowed by calling checkout or\nallow respectively.\n\nThe third option requires a {:shared, pid} mode to be set.\nIf using shared mode in tests, make sure your tests are not\nasync.\n\nThe fourth option requires [caller: pid] to be used when\nchecking out a connection from the pool. The caller process\nshould already be allowed on a connection.\n\nIf you are reading this error, it means you have not done one\nof the steps above or that the owner process has crashed.\n\nSee Ecto.Adapters.SQL.Sandbox docs for more information."}}, :not_found} policy_version=fallback
.........
Finished in 11.8 seconds (1.8s async, 9.9s sync)
304 tests, 8 failures\n\nRefs #68