### PR TITLE
feat: 扩展 #68 调度契约支持 cron/daily

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -2,7 +2,7 @@
 
 ## 项目定位
 
-**Men** 是一个 **Gateway + Webhook 集成框架**，用于接收来自多个消息平台（钉钉、飞书、企微）的事件，经过运行时执行（GongCLI/GongRPC/ZCPG RPC），再将结果回写到对应的平台。
+**Men** 是一个 **Gateway + Webhook 集成框架**，用于接收来自多个消息平台（钉钉、飞书）的事件，经过运行时执行（gong CLI），再将结果回写到对应的平台。
 
 核心职责：**入站验证 → 运行时桥接 → 出站适配**
 
@@ -10,10 +10,9 @@
 
 ## 代码统计
 
-- **总代码行数（lib/，Elixir code）**: 12,199 行
-- **核心模块数**: 91 个 `.ex/.exs` 文件
+- **总代码行数（lib/）**: 3,047 行
+- **核心模块数**: 33 个 `.ex` 文件
 - **技术栈**: Phoenix 1.7.21 + Ecto + Plug
-- **统计口径**: `cloc lib --json --quiet`（2026-02-25）
 
 ---
 
@@ -27,11 +26,9 @@ lib/men_web/
 ├── router.ex                          # 路由定义
 │   └── POST /webhooks/dingtalk        → DingtalkController.callback
 │   └── POST /webhooks/feishu          → FeishuController.create
-│   └── GET/POST /webhooks/qiwei       → QiweiController.verify/callback
 ├── controllers/
 │   ├── webhooks/dingtalk_controller.ex    # 钉钉 webhook 处理
 │   ├── webhooks/feishu_controller.ex      # 飞书 webhook 处理
-│   ├── webhooks/qiwei_controller.ex       # 企微 callback 处理
 │   └── page_controller.ex
 ├── plugs/
 │   └── raw_body_reader.ex             # 缓存原始 body（用于签名验证）
@@ -333,6 +330,111 @@ lib/
     │   ├── core_components.ex
     │   └── layouts.ex
 ```
+
+---
+
+## 任务调度契约（sub#67 基线）
+
+本节只定义契约，不引入调度执行实现。后续 Scheduler/Infra/Container 子任务必须引用本契约，禁止二义性扩展。
+
+### 契约边界
+
+- 任务主标识：`task_id`
+- 调度类型：`schedule_type`（`at | cron`，其中 `daily` 在入口归一为 `cron`）
+- 幂等键：`idempotency_key`（调用方可选业务键）
+- 状态集合：`pending | ready | running | succeeded | failed | cancelled`
+- 终态：`succeeded | failed | cancelled`，终态后禁止回到非终态
+
+### Task 字段定义
+
+| 字段 | 类型 | 约束/语义 |
+|---|---|---|
+| `task_id` | string | 系统主标识，必须唯一 |
+| `schedule_type` | enum | `at`（一次性）或 `cron`（周期） |
+| `scheduled_at` | UTC ISO8601 | `at` 任务计划触发时间 |
+| `cron_expr` | string | `cron` 任务表达式（例如 `0 3 * * *`） |
+| `timezone` | string | `cron` 任务时区（例如 `Asia/Shanghai`） |
+| `next_run_at` | UTC ISO8601 | `cron` 下一次触发时间 |
+| `last_run_at` | UTC ISO8601? | `cron` 最近一次触发时间 |
+| `schedule_id` | string? | 周期计划标识 |
+| `fire_time` | UTC ISO8601? | 本次周期实例触发时间 |
+| `state` | enum | 见状态集合 |
+| `attempt` | integer | 从 `1` 开始，表示当前第几次执行尝试 |
+| `max_retries` | integer | 最大额外重试次数 |
+| `timeout_ms` | integer | 单次执行超时（start_to_close） |
+| `idempotency_key` | string? | 可选业务幂等键 |
+| `last_error_code` | string? | 最近失败错误码 |
+| `last_error_reason` | string? | 最近失败原因 |
+| `created_at` | UTC ISO8601 | 创建时间 |
+| `updated_at` | UTC ISO8601 | 最近更新时间 |
+| `started_at` | UTC ISO8601? | 最近一次尝试开始时间 |
+| `finished_at` | UTC ISO8601? | 进入终态时间 |
+
+`max_attempts = 1 + max_retries`
+
+周期语义：
+- `cron` 任务每次执行结束后计算新的 `next_run_at`
+- 去重建议键：`schedule_id + fire_time`
+- 一次性任务继续使用 `task_id`
+
+### 状态转移矩阵
+
+| From | To | 合法性 | 说明 |
+|---|---|---|---|
+| `pending` | `ready` | 允许 | 进入可执行队列 |
+| `ready` | `running` | 允许 | 开始执行 |
+| `running` | `succeeded` | 允许 | 执行成功进入终态 |
+| `running` | `failed` | 允许 | 不可重试或重试耗尽 |
+| `running` | `ready` | 允许 | 失败但仍可重试 |
+| `pending` | `cancelled` | 允许 | 未执行即取消 |
+| `ready` | `cancelled` | 允许 | 排队中取消 |
+| `running` | `cancelled` | 允许 | 执行中取消 |
+| 其他 | 其他 | 禁止 | 统一返回 `TASK_INVALID_TRANSITION` |
+
+### 错误码契约
+
+| 错误码 | 触发条件 | 是否可触发重试 |
+|---|---|---|
+| `TASK_INVALID_TRANSITION` | 发生非法状态转移 | 否 |
+| `TASK_TIMEOUT` | 调度层 `start_to_close` 超时 | 是 |
+| `TASK_EXECUTION_FAILED` | RuntimeBridge 返回业务执行失败 | 是 |
+| `TASK_RETRY_EXHAUSTED` | 可重试错误在 `attempt >= 1 + max_retries` 后耗尽 | 否（进入 `failed`） |
+| `TASK_DUPLICATE` | 幂等命中但关键字段冲突 | 否 |
+
+`TASK_TIMEOUT` 与 `TASK_EXECUTION_FAILED` 互斥；二者都可驱动 `running -> ready` 重试。重试耗尽后必须写入 `TASK_RETRY_EXHAUSTED` 并进入 `failed`。
+
+### 幂等规则
+
+- 命中口径：
+  - 同 `task_id` 命中；或
+  - 同作用域内 `idempotency_key` 命中
+- 命中行为：
+  - 不创建新任务
+  - 不触发重复执行
+  - 返回既有任务快照
+  - 响应包含 `idempotent_hit=true`
+- 冲突行为：
+  - 若请求关键字段（建议至少包含 `schedule_type/scheduled_at/cron_expr/timezone/timeout_ms/max_retries`）与既有任务不一致
+  - 返回 `TASK_DUPLICATE` 并附冲突字段说明
+
+### 任务状态事件契约
+
+状态事件由 `EventEnvelope.normalize_task_state_event/1` 约束。
+
+- MUST：
+  - `task_id`
+  - `from_state`
+  - `to_state`
+  - `occurred_at`（UTC ISO8601）
+- SHOULD：
+  - `schedule_id`
+  - `fire_time`
+  - `attempt`
+  - `reason_code`
+  - `reason_message`
+  - `idempotent_hit`
+
+事件默认补齐 `meta.audit=true` 与 `meta.replayable=true`，并追加用于回放索引的 `ets_keys`（`task_id/from_state/to_state`）。
 
 ---
 

--- a/docs/QUICK_REFERENCE.md
+++ b/docs/QUICK_REFERENCE.md
@@ -1,236 +1,127 @@
-# Men 项目快速参考
+# Men 任务调度契约速查
 
-## 一句话定位
+本页是 sub(#67) 契约速查。后续涉及任务调度的子 issue 必须引用本页与 `docs/ARCHITECTURE.md` 的契约章节。
 
-**Men** = 多平台 Webhook Gateway + 多运行时桥接框架（GongCLI/GongRPC/ZCPG RPC）
+## 调度类型速查
 
-## 核心流程（5 步）
+- `schedule_type=at`：一次性任务，必须带 `scheduled_at`
+- `schedule_type=cron`：周期任务，必须带 `cron_expr/timezone/next_run_at`
+- `schedule_type=daily`：入口语法糖，归一化为 `cron`
+- 周期实例建议去重键：`schedule_id + fire_time`
 
-```
-1. HTTP 入站
-   POST /webhooks/{dingtalk|feishu|qiwei}
-   ↓
-2. 入站验证（Ingress）
-   签名校验 + 时间窗检查 + 重放防护 → 标准化事件
-   ↓
-3. Gateway 调度（DispatchServer）
-   事件标准化 + 去重检查 + 运行时调用 + 结果回写
-   ↓
-4. 运行时执行（Runtime Bridge）
-   GongCLI/GongRPC/ZCPG RPC + 超时控制 + 并发限制 + 清理机制
-   ↓
-5. 出站回写（Egress）
-   结果 → 渠道发送接口（钉钉/飞书）
-```
+## 状态机速查
 
-## 关键数字
+- 状态：`pending | ready | running | succeeded | failed | cancelled`
+- 终态：`succeeded | failed | cancelled`
+- 合法转移：
+  - `pending -> ready`
+  - `ready -> running`
+  - `running -> succeeded`
+  - `running -> failed`
+  - `running -> ready`（可重试）
+  - `pending|ready|running -> cancelled`
+- 非法转移统一错误码：`TASK_INVALID_TRANSITION`
 
-| 指标 | 值 |
-|------|-----|
-| 总代码行数（lib/，Elixir code） | 12,199 |
-| Elixir 文件数（.ex/.exs） | 91 |
-| 超时默认值 | 30 秒 |
-| 最大并发数 | 10 |
-| 时间窗（钉钉） | 5 分钟 |
-| 支持平台 | 钉钉、飞书、企微 |
+## attempt 速查
 
-统计口径：`cloc lib --json --quiet`（2026-02-25）
+- `attempt` 从 `1` 开始，表示当前第几次执行尝试
+- `max_retries` 是“最大额外重试次数”
+- `max_attempts = 1 + max_retries`
+- 当 `attempt >= max_attempts` 且错误属于可重试错误（`TASK_TIMEOUT` / `TASK_EXECUTION_FAILED`）时：
+  - 任务进入 `failed`
+  - `last_error_code = TASK_RETRY_EXHAUSTED`
 
-## 模块职责速查
+## 错误码速查
 
-| 模块 | 职责 |
-|------|------|
-| `MenWeb.Endpoint` | HTTP 服务启动 + Plug 配置 |
-| `DingtalkController` | 钉钉 webhook 入口，编排 ingress→dispatch→egress |
-| `FeishuController` | 飞书 webhook 入口，编排 ingress→dispatch→egress |
-| `DingtalkIngress` | 钉钉签名验证（HMAC-SHA256）+ 事件标准化 |
-| `FeishuIngress` | 飞书签名验证（SHA256）+ 重放检测（ETS）+ 事件标准化 |
-| `DispatchServer` | GenServer L1 主状态机，编排 bridge→egress |
-| `GongCLI` | Port 子进程执行，超时/并发控制，进程清理 |
-| `DingtalkEgress` | 结果发送到钉钉（支持 webhook / app_robot） |
-| `FeishuEgress` | 结果映射为飞书 webhook 响应 |
-| `SessionKey` | 会话键生成规则 |
+| 错误码 | 含义 |
+|---|---|
+| `TASK_INVALID_TRANSITION` | 非法状态转移 |
+| `TASK_TIMEOUT` | 调度层 start_to_close 超时 |
+| `TASK_EXECUTION_FAILED` | RuntimeBridge 业务执行失败 |
+| `TASK_RETRY_EXHAUSTED` | 可重试错误达到上限后耗尽 |
+| `TASK_DUPLICATE` | 幂等命中但关键字段冲突 |
 
-## 错误分类
+## 示例载荷
 
-| 错误类型 | Code | 说明 | 是否标记已处理 |
-|---------|------|------|----------------|
-| Invalid Signature | INVALID_SIGNATURE | 签名校验失败 | ✓ |
-| Timestamp Expired | SIGNATURE_EXPIRED | 时间戳过期 | ✓ |
-| CLI Timeout | CLI_TIMEOUT | 执行超时 | ✓ |
-| CLI Exit Non-Zero | CLI_EXIT_N | 执行失败（exit code N） | ✓ |
-| Overloaded | CLI_OVERLOADED | 并发超限 | ✓ |
-| Egress Error | EGRESS_ERROR | 回写失败 | ✗（允许重试） |
+### 创建任务请求（at）
 
-## 配置关键字
-
-```elixir
-# Gateway
-:men, Men.Gateway.DispatchServer,
-  bridge_adapter: ...    # 运行时桥接实现
-  egress_adapter: ...    # 出站适配实现
-  storage_adapter: ...   # 去重存储（内存/Redis）
-
-# GongCLI
-:men, Men.RuntimeBridge.GongCLI,
-  command: "gong"        # 可执行程序路径或名称
-  timeout_ms: 30_000     # 超时时间（毫秒）
-  max_concurrency: 10    # 最大并发数
-  prompt_arg: "--prompt" # 参数名
-  request_id_arg: "--request-id"
-  session_key_arg: "--session-key"
-  run_id_arg: "--run-id"
-
-# 钉钉
-:men, Men.Channels.Ingress.DingtalkAdapter,
-  secret: {:system, "DINGTALK_WEBHOOK_SECRET"}
-  signature_window_seconds: 300
-
-# 飞书
-:men, Men.Channels.Ingress.FeishuAdapter,
-  bots: %{
-    "app_id_1" => "secret_1",
-    "app_id_2" => "secret_2"
+```json
+{
+  "task_id": "task_20260225_0001",
+  "schedule_type": "at",
+  "scheduled_at": "2026-02-25T12:00:00Z",
+  "timeout_ms": 30000,
+  "max_retries": 2,
+  "idempotency_key": "order_1001",
+  "idempotency_scope": "tenant_a",
+  "payload": {
+    "channel": "dingtalk",
+    "request_id": "req-1"
   }
-  signature_window_seconds: 300
+}
 ```
 
-### 钉钉出站适配模式
+### 创建任务请求（cron / daily）
 
-`Men.Channels.Egress.DingtalkRobotAdapter` 支持两种模式：
-
-1. `webhook`（默认兼容模式）
-   - 环境变量：`DINGTALK_ROBOT_WEBHOOK_URL`、`DINGTALK_ROBOT_SECRET`、`DINGTALK_ROBOT_SIGN_ENABLED`
-2. `app_robot`（robotCode 模式）
-   - 环境变量：`DINGTALK_ROBOT_MODE=app_robot`
-   - 必填：`DINGTALK_ROBOT_CODE`、`DINGTALK_APP_KEY`、`DINGTALK_APP_SECRET`
-   - 可选：`DINGTALK_TOKEN_URL`、`DINGTALK_ROBOT_OTO_SEND_URL`
-
-## 运行时依赖
-
-- **Erlang Port**: 启动子进程 (`gong` 命令)
-- **ETS**: 并发计数 + 飞书重放检测
-- **PostgreSQL**: Repo（配置但未使用）
-- **Swoosh**: 邮件（配置但未使用）
-
-## 已处理去重机制
-
-- **存储**: 内存 MapSet（`processed_run_ids`）
-- **范围**: 单进程 DispatchServer 生命周期
-- **重启丢失**: ✓ 需持久化建议使用 Redis
-- **幂等保障**: 同 `run_id` 不重复执行（egress 失败除外）
-
-## 全链路追踪 ID
-
-```
-request_id   → 唯一标识单次 HTTP 请求
-session_key  → 唯一标识会话（channel:user_id[:g:group_id][:t:thread_id]）
-run_id       → 唯一标识单次执行（幂等重试）
+```json
+{
+  "task_id": "task_20260225_daily_0001",
+  "schedule_type": "daily",
+  "cron_expr": "0 3 * * *",
+  "timezone": "Asia/Shanghai",
+  "next_run_at": "2026-02-26T03:00:00Z",
+  "timeout_ms": 30000,
+  "max_retries": 2,
+  "schedule_id": "schedule_daily_cleanup",
+  "payload": {
+    "channel": "dingtalk",
+    "request_id": "req-2"
+  }
+}
 ```
 
-## 超时处理流程
+### 状态事件（running -> failed）
 
-```
-1. 启动 Port 子进程执行 gong CLI
-2. receive {...after timeout_ms} 等待输出
-3. 超时触发 → cleanup_timed_out_port()
-   a) Port.close(port)
-   b) pkill -P <os_pid> -TERM   (终止直接子进程)
-   c) kill -TERM <os_pid>        (SIGTERM 主进程)
-   d) sleep 30ms
-   e) kill -KILL <os_pid>        (SIGKILL 强制杀进程)
-4. 返回 {:timeout, output, cleanup_result}
-```
-
-## GongCLI 参数传递示例
-
-```bash
-# Elixir 调用
-gong \
-  --prompt '{"content":"用户消息","channel":"dingtalk"}' \
-  --request-id 'req_abc123' \
-  --session-key 'dingtalk:user_456:g:group_789' \
-  --run-id 'run_xyz'
-
-# gong 应收到 stdin
-$STDIN = '{"content":"用户消息","channel":"dingtalk"}'
-
-# gong 应输出到 stdout
-Generate result text...
-# 以及 exit code
-0  ← success
-1  ← failure
+```json
+{
+  "type": "task_state_changed",
+  "source": "gateway.scheduler",
+  "session_key": "scheduler:default",
+  "event_id": "evt_task_1",
+  "payload": {
+    "task_id": "task_20260225_0001",
+    "from_state": "running",
+    "to_state": "failed",
+    "occurred_at": "2026-02-25T12:00:30Z",
+    "schedule_id": "schedule_daily_cleanup",
+    "fire_time": "2026-02-25T03:00:00Z",
+    "attempt": 3,
+    "reason_code": "TASK_RETRY_EXHAUSTED",
+    "reason_message": "start_to_close timeout exhausted retries",
+    "idempotent_hit": false
+  }
+}
 ```
 
-## 新增平台适配检查清单
+### 幂等命中响应（不重复创建）
 
-- [ ] 实现 `*.Ingress.SlackAdapter` 
-  - [ ] `normalize/1` → 验签 + 标准化
-  - [ ] 实现 `@behaviour Men.Channels.Ingress.Adapter`
-  
-- [ ] 实现 `*.Egress.SlackAdapter`
-  - [ ] `send/2` → 发送消息
-  - [ ] `to_webhook_response/1` → 映射响应
-  - [ ] 实现 `@behaviour Men.Channels.Egress.Adapter`
-  
-- [ ] 新增 Controller
-  - [ ] `MenWeb.Webhooks.SlackController`
-  - [ ] 编排 ingress → dispatch → egress
-  
-- [ ] 更新 Router
-  - [ ] `POST /webhooks/slack`
-  
-- [ ] 添加配置
-  - [ ] `:men, Men.Channels.Ingress.SlackAdapter, [...]`
-  
-- [ ] 编写测试
-  - [ ] 签名验证测试
-  - [ ] 事件标准化测试
-  - [ ] 端到端集成测试
-
-## 常见问题
-
-### Q1: run_id 重复时会发生什么？
-A: DispatchServer 检查 `MapSet.member?(run_id)`，若已存在返回 `{:ok, :duplicate}`，不再执行。
-
-### Q2: 超时后子进程是否确保被清理？
-A: 是。`cleanup_timed_out_port()` 会执行 `pkill -P <pid>` + `kill -TERM/KILL`，确保进程树被清理。
-
-### Q3: 支持持久化去重吗？
-A: 目前仅支持内存。建议通过配置注入自定义 `storage_adapter` 实现 Redis 持久化。
-
-### Q4: 飞书重放防护如何工作？
-A: ETS 表记录 nonce + TTL，每次请求检查 `seen_nonce?`。ETS 自动清理过期数据。
-
-### Q5: GongCLI 超时的默认值是多少？
-A: 30 秒（可配置 `timeout_ms`）。
-
-## 代码入口
-
-```elixir
-# 启动
-lib/men/application.ex
-  {Men.Gateway.DispatchServer, []}
-
-# HTTP 路由
-lib/men_web/router.ex
-  post "/webhooks/dingtalk", DingtalkController, :callback
-  post "/webhooks/feishu", FeishuController, :create
-
-# 主调度逻辑
-lib/men/gateway/dispatch_server.ex
-  def dispatch(server, inbound_event)
-
-# 运行时执行
-lib/men/runtime_bridge/gong_cli.ex
-  def start_turn(prompt, context)
+```json
+{
+  "idempotent_hit": true,
+  "task": {
+    "task_id": "task_20260225_0001",
+    "schedule_type": "at",
+    "state": "ready",
+    "attempt": 1,
+    "max_retries": 2,
+    "timeout_ms": 30000,
+    "idempotency_key": "order_1001",
+    "last_error_code": null,
+    "last_error_reason": null,
+    "created_at": "2026-02-25T11:59:58Z",
+    "updated_at": "2026-02-25T11:59:58Z",
+    "started_at": null,
+    "finished_at": null
+  }
+}
 ```
-
-## 扩展思路
-
-1. **存储层**: Redis → 分布式去重
-2. **队列**: Oban/Broadway → 异步处理 + 重试策略
-3. **可观测**: Prometheus → 性能指标 + 告警
-4. **实时推送**: WebSocket → 客户端进度更新
-5. **插件系统**: 动态加载 Ingress/Egress 适配器
-6. **审计日志**: 数据库 + 时间戳 + 操作者追踪

--- a/lib/men/gateway/types.ex
+++ b/lib/men/gateway/types.ex
@@ -3,6 +3,31 @@ defmodule Men.Gateway.Types do
   Gateway Dispatch 协议类型定义。
   """
 
+  @task_states [:pending, :ready, :running, :succeeded, :failed, :cancelled]
+  @terminal_task_states [:succeeded, :failed, :cancelled]
+  @valid_task_transitions MapSet.new([
+                            {:pending, :ready},
+                            {:ready, :running},
+                            {:running, :succeeded},
+                            {:running, :failed},
+                            {:running, :ready},
+                            {:pending, :cancelled},
+                            {:ready, :cancelled},
+                            {:running, :cancelled}
+                          ])
+
+  @task_schedule_types [:at, :cron]
+  @retryable_error_codes MapSet.new(["TASK_TIMEOUT", "TASK_EXECUTION_FAILED"])
+
+  @idempotency_critical_fields [
+    :schedule_type,
+    :scheduled_at,
+    :cron_expr,
+    :timezone,
+    :timeout_ms,
+    :max_retries
+  ]
+
   @typedoc """
   入站事件统一结构。
 
@@ -130,4 +155,295 @@ defmodule Men.Gateway.Types do
               required(:runtime_session_id) => binary(),
               required(:code) => atom() | binary()
             }
+
+  @typedoc """
+  任务调度类型。
+
+  - `:at`：一次性触发
+  - `:cron`：周期触发（`daily` 在入口归一为 `:cron`）
+  """
+  @type task_schedule_type :: :at | :cron
+
+  @typedoc """
+  任务状态。终态为 `:succeeded | :failed | :cancelled`。
+  """
+  @type task_state :: :pending | :ready | :running | :succeeded | :failed | :cancelled
+
+  @typedoc """
+  任务契约错误码。
+  """
+  @type task_error_code :: binary()
+
+  @typedoc """
+  任务快照契约。
+  """
+  @type task_snapshot :: %{
+          required(:task_id) => binary(),
+          required(:schedule_type) => task_schedule_type(),
+          optional(:scheduled_at) => DateTime.t() | nil,
+          optional(:cron_expr) => binary() | nil,
+          optional(:timezone) => binary() | nil,
+          optional(:next_run_at) => DateTime.t() | nil,
+          optional(:last_run_at) => DateTime.t() | nil,
+          optional(:schedule_id) => binary() | nil,
+          optional(:fire_time) => DateTime.t() | nil,
+          required(:state) => task_state(),
+          required(:attempt) => pos_integer(),
+          required(:max_retries) => non_neg_integer(),
+          required(:timeout_ms) => pos_integer(),
+          optional(:idempotency_key) => binary() | nil,
+          optional(:last_error_code) => task_error_code() | nil,
+          optional(:last_error_reason) => binary() | nil,
+          required(:created_at) => DateTime.t(),
+          required(:updated_at) => DateTime.t(),
+          optional(:started_at) => DateTime.t() | nil,
+          optional(:finished_at) => DateTime.t() | nil
+        }
+
+  @typedoc """
+  任务状态事件载荷契约。
+  """
+  @type task_state_event_payload :: %{
+          required(:task_id) => binary(),
+          required(:from_state) => task_state(),
+          required(:to_state) => task_state(),
+          required(:occurred_at) => binary(),
+          optional(:schedule_id) => binary(),
+          optional(:fire_time) => binary(),
+          optional(:attempt) => pos_integer(),
+          optional(:reason_code) => binary(),
+          optional(:reason_message) => binary(),
+          optional(:idempotent_hit) => boolean()
+        }
+
+  @typedoc """
+  创建任务的幂等请求视图。
+  """
+  @type task_idempotency_request :: %{
+          required(:task_id) => binary(),
+          optional(:idempotency_key) => binary() | nil,
+          optional(:idempotency_scope) => binary() | nil
+        }
+
+  @typedoc """
+  幂等冲突错误结构。
+  """
+  @type task_duplicate_error :: %{
+          required(:code) => binary(),
+          required(:reason) => binary(),
+          required(:conflict_fields) => [atom()],
+          required(:task) => task_snapshot()
+        }
+
+  @spec task_schedule_types() :: [task_schedule_type()]
+  def task_schedule_types, do: @task_schedule_types
+
+  @spec normalize_task_schedule_type(term()) :: {:ok, task_schedule_type()} | {:error, term()}
+  def normalize_task_schedule_type(:at), do: {:ok, :at}
+  def normalize_task_schedule_type(:cron), do: {:ok, :cron}
+  def normalize_task_schedule_type(:daily), do: {:ok, :cron}
+  def normalize_task_schedule_type("at"), do: {:ok, :at}
+  def normalize_task_schedule_type("cron"), do: {:ok, :cron}
+  def normalize_task_schedule_type("daily"), do: {:ok, :cron}
+
+  def normalize_task_schedule_type(_),
+    do: {:error, %{code: "TASK_INVALID_SCHEDULE", field: :schedule_type}}
+
+  @spec validate_task_schedule(map()) :: :ok | {:error, %{code: binary(), field: atom()}}
+  def validate_task_schedule(task) when is_map(task) do
+    with {:ok, schedule_type} <- normalize_task_schedule_type(Map.get(task, :schedule_type)),
+         :ok <- validate_schedule_required_fields(schedule_type, task),
+         :ok <- validate_schedule_optional_fields(task) do
+      :ok
+    end
+  end
+
+  def validate_task_schedule(_), do: {:error, %{code: "TASK_INVALID_SCHEDULE", field: :task}}
+
+  @spec task_states() :: [task_state()]
+  def task_states, do: @task_states
+
+  @spec terminal_task_states() :: [task_state()]
+  def terminal_task_states, do: @terminal_task_states
+
+  @spec terminal_task_state?(task_state() | term()) :: boolean()
+  def terminal_task_state?(state), do: state in @terminal_task_states
+
+  @spec valid_task_transition?(task_state() | term(), task_state() | term()) :: boolean()
+  def valid_task_transition?(from_state, to_state) do
+    MapSet.member?(@valid_task_transitions, {from_state, to_state})
+  end
+
+  @spec validate_task_transition(task_state() | term(), task_state() | term()) ::
+          :ok
+          | {:error,
+             %{
+               code: binary(),
+               from_state: task_state() | term(),
+               to_state: task_state() | term()
+             }}
+  def validate_task_transition(from_state, to_state) do
+    if valid_task_transition?(from_state, to_state) do
+      :ok
+    else
+      {:error,
+       %{
+         code: "TASK_INVALID_TRANSITION",
+         from_state: from_state,
+         to_state: to_state
+       }}
+    end
+  end
+
+  @spec max_attempts(non_neg_integer()) :: pos_integer()
+  def max_attempts(max_retries) when is_integer(max_retries) and max_retries >= 0 do
+    1 + max_retries
+  end
+
+  @spec retry_exhausted?(pos_integer(), non_neg_integer()) :: boolean()
+  def retry_exhausted?(attempt, max_retries)
+      when is_integer(attempt) and attempt >= 1 and is_integer(max_retries) and max_retries >= 0 do
+    attempt >= max_attempts(max_retries)
+  end
+
+  @spec retryable_error_code?(binary() | term()) :: boolean()
+  def retryable_error_code?(code) when is_binary(code),
+    do: MapSet.member?(@retryable_error_codes, code)
+
+  def retryable_error_code?(_), do: false
+
+  @spec final_failure_code(pos_integer(), non_neg_integer(), binary() | nil) :: binary() | nil
+  def final_failure_code(attempt, max_retries, reason_code)
+      when is_integer(attempt) and attempt >= 1 and is_integer(max_retries) and max_retries >= 0 do
+    if retryable_error_code?(reason_code) and retry_exhausted?(attempt, max_retries) do
+      "TASK_RETRY_EXHAUSTED"
+    else
+      reason_code
+    end
+  end
+
+  @spec idempotent_hit?(task_snapshot() | map(), task_idempotency_request() | map()) :: boolean()
+  def idempotent_hit?(existing_task, request) when is_map(existing_task) and is_map(request) do
+    same_task_id?(existing_task, request) or same_scoped_idempotency_key?(existing_task, request)
+  end
+
+  @spec resolve_idempotent_request(task_snapshot() | map(), map(), keyword()) ::
+          {:ok, %{idempotent_hit: false}}
+          | {:ok, %{task: task_snapshot() | map(), idempotent_hit: true}}
+          | {:error, task_duplicate_error()}
+  def resolve_idempotent_request(existing_task, request, opts \\ [])
+      when is_map(existing_task) and is_map(request) do
+    if idempotent_hit?(existing_task, request) do
+      critical_fields = Keyword.get(opts, :critical_fields, @idempotency_critical_fields)
+
+      conflict_fields =
+        critical_fields
+        |> Enum.filter(&Map.has_key?(request, &1))
+        |> Enum.reject(&(Map.get(existing_task, &1) == Map.get(request, &1)))
+
+      if conflict_fields == [] do
+        {:ok, %{task: existing_task, idempotent_hit: true}}
+      else
+        {:error,
+         %{
+           code: "TASK_DUPLICATE",
+           reason: "idempotency key matched but critical fields conflicted",
+           conflict_fields: conflict_fields,
+           task: existing_task
+         }}
+      end
+    else
+      {:ok, %{idempotent_hit: false}}
+    end
+  end
+
+  defp same_task_id?(existing_task, request) do
+    existing_task_id = Map.get(existing_task, :task_id)
+    request_task_id = Map.get(request, :task_id)
+    is_binary(existing_task_id) and existing_task_id != "" and existing_task_id == request_task_id
+  end
+
+  defp same_scoped_idempotency_key?(existing_task, request) do
+    existing_key = Map.get(existing_task, :idempotency_key)
+    request_key = Map.get(request, :idempotency_key)
+
+    existing_scope = Map.get(existing_task, :idempotency_scope)
+    request_scope = Map.get(request, :idempotency_scope)
+
+    is_binary(existing_key) and existing_key != "" and existing_key == request_key and
+      existing_scope == request_scope
+  end
+
+  defp validate_schedule_required_fields(:at, task) do
+    require_datetime_field(task, :scheduled_at)
+  end
+
+  defp validate_schedule_required_fields(:cron, task) do
+    with :ok <- require_text_field(task, :cron_expr),
+         :ok <- require_text_field(task, :timezone),
+         :ok <- require_datetime_field(task, :next_run_at) do
+      :ok
+    end
+  end
+
+  defp validate_schedule_optional_fields(task) do
+    with :ok <- validate_optional_datetime(task, :scheduled_at),
+         :ok <- validate_optional_datetime(task, :next_run_at),
+         :ok <- validate_optional_datetime(task, :last_run_at),
+         :ok <- validate_optional_datetime(task, :fire_time) do
+      :ok
+    end
+  end
+
+  defp require_text_field(task, field) do
+    case Map.get(task, field) do
+      value when is_binary(value) ->
+        if byte_size(String.trim(value)) > 0 do
+          :ok
+        else
+          {:error, %{code: "TASK_INVALID_SCHEDULE", field: field}}
+        end
+
+      _ ->
+        {:error, %{code: "TASK_INVALID_SCHEDULE", field: field}}
+    end
+  end
+
+  defp require_datetime_field(task, field) do
+    case Map.get(task, field) do
+      nil ->
+        {:error, %{code: "TASK_INVALID_SCHEDULE", field: field}}
+
+      value ->
+        value
+        |> normalize_datetime_field()
+        |> case do
+          {:ok, _} -> :ok
+          :error -> {:error, %{code: "TASK_INVALID_SCHEDULE", field: field}}
+        end
+    end
+  end
+
+  defp validate_optional_datetime(task, field) do
+    task
+    |> Map.get(field)
+    |> normalize_datetime_field()
+    |> case do
+      {:ok, _} -> :ok
+      :error -> {:error, %{code: "TASK_INVALID_SCHEDULE", field: field}}
+    end
+  end
+
+  defp normalize_datetime_field(nil), do: {:ok, nil}
+  defp normalize_datetime_field(%DateTime{} = dt), do: {:ok, dt}
+
+  defp normalize_datetime_field(value) when is_binary(value) do
+    with {:ok, dt, 0} <- DateTime.from_iso8601(String.trim(value)) do
+      {:ok, dt}
+    else
+      _ -> :error
+    end
+  end
+
+  defp normalize_datetime_field(_), do: :error
 end

--- a/test/men/gateway/event_envelope_test.exs
+++ b/test/men/gateway/event_envelope_test.exs
@@ -61,4 +61,147 @@ defmodule Men.Gateway.EventEnvelopeTest do
                payload: %{}
              })
   end
+
+  test "任务状态事件契约归一化并补齐审计元数据" do
+    input = %{
+      type: "task_state_changed",
+      source: "gateway.scheduler",
+      session_key: "scheduler:default",
+      event_id: "evt-task-1",
+      payload: %{
+        task_id: "task-1",
+        from_state: "running",
+        to_state: "failed",
+        occurred_at: "2026-02-25T03:42:00Z",
+        schedule_id: "schedule-daily-1",
+        fire_time: "2026-02-25T03:00:00Z",
+        attempt: 2,
+        reason_code: "TASK_TIMEOUT",
+        reason_message: "start_to_close timeout",
+        idempotent_hit: false
+      }
+    }
+
+    assert {:ok, envelope} = EventEnvelope.normalize_task_state_event(input)
+    assert envelope.type == "task_state_changed"
+    assert envelope.payload.task_id == "task-1"
+    assert envelope.payload.from_state == :running
+    assert envelope.payload.to_state == :failed
+    assert envelope.payload.occurred_at == "2026-02-25T03:42:00Z"
+    assert envelope.payload.schedule_id == "schedule-daily-1"
+    assert envelope.payload.fire_time == "2026-02-25T03:00:00Z"
+    assert envelope.payload.attempt == 2
+    assert envelope.payload.reason_code == "TASK_TIMEOUT"
+    assert envelope.payload.reason_message == "start_to_close timeout"
+    assert envelope.payload.idempotent_hit == false
+    assert envelope.meta.audit == true
+    assert envelope.meta.replayable == true
+    assert "task-1" in envelope.ets_keys
+    assert "running" in envelope.ets_keys
+    assert "failed" in envelope.ets_keys
+    assert "schedule-daily-1" in envelope.ets_keys
+    assert "2026-02-25T03:00:00Z" in envelope.ets_keys
+  end
+
+  test "任务状态事件遇到非法转移返回 TASK_INVALID_TRANSITION" do
+    assert {:error,
+            %{code: "TASK_INVALID_TRANSITION", from_state: :succeeded, to_state: :running}} =
+             EventEnvelope.normalize_task_state_event(%{
+               type: "task_state_changed",
+               source: "gateway.scheduler",
+               session_key: "scheduler:default",
+               event_id: "evt-task-invalid-transition",
+               payload: %{
+                 task_id: "task-1",
+                 from_state: "succeeded",
+                 to_state: "running",
+                 occurred_at: "2026-02-25T03:42:00Z"
+               }
+             })
+  end
+
+  test "任务状态事件要求 UTC ISO8601 occurred_at" do
+    assert {:error, {:invalid_field, :occurred_at}} =
+             EventEnvelope.normalize_task_state_event(%{
+               type: "task_state_changed",
+               source: "gateway.scheduler",
+               session_key: "scheduler:default",
+               event_id: "evt-task-time-invalid",
+               payload: %{
+                 task_id: "task-1",
+                 from_state: "pending",
+                 to_state: "ready",
+                 occurred_at: "2026-02-25T11:42:00+08:00"
+               }
+             })
+  end
+
+  test "任务状态事件 reason_code 非法类型返回 :reason_code" do
+    assert {:error, {:invalid_field, :reason_code}} =
+             EventEnvelope.normalize_task_state_event(%{
+               type: "task_state_changed",
+               source: "gateway.scheduler",
+               session_key: "scheduler:default",
+               event_id: "evt-task-reason-code-invalid",
+               payload: %{
+                 task_id: "task-1",
+                 from_state: "pending",
+                 to_state: "ready",
+                 occurred_at: "2026-02-25T03:42:00Z",
+                 reason_code: 123
+               }
+             })
+  end
+
+  test "任务状态事件 reason_message 非法类型返回 :reason_message" do
+    assert {:error, {:invalid_field, :reason_message}} =
+             EventEnvelope.normalize_task_state_event(%{
+               type: "task_state_changed",
+               source: "gateway.scheduler",
+               session_key: "scheduler:default",
+               event_id: "evt-task-reason-message-invalid",
+               payload: %{
+                 task_id: "task-1",
+                 from_state: "pending",
+                 to_state: "ready",
+                 occurred_at: "2026-02-25T03:42:00Z",
+                 reason_message: 123
+               }
+             })
+  end
+
+  test "任务状态事件 fire_time 缺失时返回 :fire_time" do
+    assert {:error, {:invalid_field, :fire_time}} =
+             EventEnvelope.normalize_task_state_event(%{
+               type: "task_state_changed",
+               source: "gateway.scheduler",
+               session_key: "scheduler:default",
+               event_id: "evt-task-fire-time-missing",
+               payload: %{
+                 task_id: "task-1",
+                 from_state: "pending",
+                 to_state: "ready",
+                 occurred_at: "2026-02-25T03:42:00Z",
+                 schedule_id: "schedule-daily-1"
+               }
+             })
+  end
+
+  test "任务状态事件 fire_time 非 UTC ISO8601 返回 :fire_time" do
+    assert {:error, {:invalid_field, :fire_time}} =
+             EventEnvelope.normalize_task_state_event(%{
+               type: "task_state_changed",
+               source: "gateway.scheduler",
+               session_key: "scheduler:default",
+               event_id: "evt-task-fire-time-invalid",
+               payload: %{
+                 task_id: "task-1",
+                 from_state: "pending",
+                 to_state: "ready",
+                 occurred_at: "2026-02-25T03:42:00Z",
+                 schedule_id: "schedule-daily-1",
+                 fire_time: "2026-02-25T11:00:00+08:00"
+               }
+             })
+  end
 end

--- a/test/men/gateway/types_test.exs
+++ b/test/men/gateway/types_test.exs
@@ -1,0 +1,153 @@
+defmodule Men.Gateway.TypesTest do
+  use ExUnit.Case, async: true
+
+  alias Men.Gateway.Types
+
+  test "schedule_type 支持 at/cron，daily 归一到 cron" do
+    assert Types.task_schedule_types() == [:at, :cron]
+    assert {:ok, :at} = Types.normalize_task_schedule_type(:at)
+    assert {:ok, :cron} = Types.normalize_task_schedule_type("cron")
+    assert {:ok, :cron} = Types.normalize_task_schedule_type("daily")
+
+    assert {:error, %{code: "TASK_INVALID_SCHEDULE", field: :schedule_type}} =
+             Types.normalize_task_schedule_type("weekly")
+  end
+
+  test "validate_task_schedule 校验 at 与 cron 必填字段" do
+    assert :ok =
+             Types.validate_task_schedule(%{
+               schedule_type: :at,
+               scheduled_at: "2026-02-26T03:42:00Z"
+             })
+
+    assert :ok =
+             Types.validate_task_schedule(%{
+               schedule_type: :cron,
+               cron_expr: "0 3 * * *",
+               timezone: "Asia/Shanghai",
+               next_run_at: ~U[2026-02-26 03:00:00Z]
+             })
+
+    assert {:error, %{code: "TASK_INVALID_SCHEDULE", field: :next_run_at}} =
+             Types.validate_task_schedule(%{
+               schedule_type: :cron,
+               cron_expr: "0 3 * * *",
+               timezone: "Asia/Shanghai"
+             })
+  end
+
+  test "at 任务流转合法且终态后禁止返回非终态" do
+    assert :ok == Types.validate_task_transition(:pending, :ready)
+    assert :ok == Types.validate_task_transition(:ready, :running)
+    assert :ok == Types.validate_task_transition(:running, :succeeded)
+
+    assert {:error, %{code: "TASK_INVALID_TRANSITION"}} =
+             Types.validate_task_transition(:succeeded, :running)
+  end
+
+  test "同 task_id 或同作用域 idempotency_key 命中时返回幂等命中" do
+    task = %{
+      task_id: "task-1",
+      idempotency_key: "order-1001",
+      idempotency_scope: "tenant-a",
+      schedule_type: :at,
+      max_retries: 2,
+      timeout_ms: 30_000
+    }
+
+    assert Types.idempotent_hit?(task, %{task_id: "task-1"})
+
+    assert Types.idempotent_hit?(task, %{
+             task_id: "task-another",
+             idempotency_key: "order-1001",
+             idempotency_scope: "tenant-a"
+           })
+
+    assert {:ok, %{idempotent_hit: true, task: ^task}} =
+             Types.resolve_idempotent_request(task, %{
+               task_id: "task-1",
+               schedule_type: :at,
+               max_retries: 2,
+               timeout_ms: 30_000
+             })
+  end
+
+  test "幂等命中但关键字段冲突时返回 TASK_DUPLICATE" do
+    task = %{
+      task_id: "task-1",
+      schedule_type: :at,
+      scheduled_at: ~U[2026-02-25 03:42:00Z],
+      max_retries: 2,
+      timeout_ms: 30_000
+    }
+
+    assert {:error,
+            %{
+              code: "TASK_DUPLICATE",
+              conflict_fields: [:timeout_ms]
+            }} =
+             Types.resolve_idempotent_request(task, %{
+               task_id: "task-1",
+               schedule_type: :at,
+               scheduled_at: ~U[2026-02-25 03:42:00Z],
+               max_retries: 2,
+               timeout_ms: 10_000
+             })
+  end
+
+  test "cron 任务幂等命中且 cron 关键字段冲突时返回 TASK_DUPLICATE" do
+    task = %{
+      task_id: "task-cron-1",
+      schedule_type: :cron,
+      cron_expr: "0 3 * * *",
+      timezone: "Asia/Shanghai",
+      next_run_at: ~U[2026-02-26 03:00:00Z],
+      max_retries: 2,
+      timeout_ms: 30_000
+    }
+
+    assert {:error, %{code: "TASK_DUPLICATE", conflict_fields: [:timezone]}} =
+             Types.resolve_idempotent_request(task, %{
+               task_id: "task-cron-1",
+               schedule_type: :cron,
+               cron_expr: "0 3 * * *",
+               timezone: "UTC",
+               max_retries: 2,
+               timeout_ms: 30_000
+             })
+  end
+
+  test "未命中幂等时返回 idempotent_hit=false" do
+    task = %{
+      task_id: "task-1",
+      schedule_type: :at,
+      max_retries: 2,
+      timeout_ms: 30_000
+    }
+
+    assert {:ok, %{idempotent_hit: false}} =
+             Types.resolve_idempotent_request(task, %{
+               task_id: "task-2",
+               schedule_type: :at,
+               max_retries: 2,
+               timeout_ms: 30_000
+             })
+  end
+
+  test "超时与执行失败都可重试且重试耗尽后落 TASK_RETRY_EXHAUSTED" do
+    assert Types.retryable_error_code?("TASK_TIMEOUT")
+    assert Types.retryable_error_code?("TASK_EXECUTION_FAILED")
+    refute Types.retryable_error_code?("TASK_INVALID_TRANSITION")
+
+    assert Types.max_attempts(2) == 3
+    assert Types.retry_exhausted?(3, 2)
+
+    assert Types.final_failure_code(3, 2, "TASK_TIMEOUT") == "TASK_RETRY_EXHAUSTED"
+    assert Types.final_failure_code(3, 2, "TASK_EXECUTION_FAILED") == "TASK_RETRY_EXHAUSTED"
+  end
+
+  test "running 可取消并进入终态" do
+    assert :ok == Types.validate_task_transition(:running, :cancelled)
+    assert Types.terminal_task_state?(:cancelled)
+  end
+end


### PR DESCRIPTION
## Summary
- 扩展 `Men.Gateway.Types` 调度契约：`schedule_type` 从 `at` 扩展为 `at|cron`，并将 `daily` 入口归一为 `cron`
- 新增任务调度契约校验函数 `validate_task_schedule/1`，覆盖 `at` 与 `cron` 的必填字段校验
- 扩展任务幂等关键字段（加入 `cron_expr/timezone`）
- 扩展 `EventEnvelope.normalize_task_state_event/1` 周期实例字段：`schedule_id/fire_time`，并增加字段配对校验
- 更新 `docs/ARCHITECTURE.md` 与 `docs/QUICK_REFERENCE.md`，补齐 daily/cron 契约说明和示例
- 增加/更新测试：`types_test` 与 `event_envelope_test`

## Test plan
- `mix test test/men/gateway/types_test.exs test/men/gateway/event_envelope_test.exs` ✅
- `mix test` ⚠️ 失败（当前 `master` 基线已有集成失败，集中在 `test/integration/agent_loop_receipt_flow_test.exs`，报 `DispatchServer.push_receipt/2` 未定义，与本 PR 改动范围无交集）

Refs #68
