### PR TITLE
fix: sub(#67): Gateway 调度骨架（TaskScheduler/TaskDispatcher） (#69)

### DIFF
--- a/.github/scripts/niuma-test-gate.sh
+++ b/.github/scripts/niuma-test-gate.sh
@@ -1,6 +1,114 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+log() {
+  echo "[gate] $*"
+}
+
+usage() {
+  echo "usage: $0 <pr-number>" >&2
+}
+
+if [[ $# -ne 1 ]]; then
+  usage
+  exit 2
+fi
+
+PR_NUMBER="$1"
+if ! [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
+  echo "invalid pr-number: $PR_NUMBER" >&2
+  usage
+  exit 2
+fi
+
+if [[ -z "${GITHUB_TOKEN:-}" ]]; then
+  echo "GITHUB_TOKEN is required" >&2
+  exit 2
+fi
+
+HEAD_REF=$(gh pr view "$PR_NUMBER" --json headRefName --jq '.headRefName')
+BASE_REF=$(gh pr view "$PR_NUMBER" --json baseRefName --jq '.baseRefName')
+HEAD_SHA=$(gh pr view "$PR_NUMBER" --json headRefOid --jq '.headRefOid')
+BASE_SHA=$(gh pr view "$PR_NUMBER" --json baseRefOid --jq '.baseRefOid')
+
+if [[ -z "$HEAD_REF" || "$HEAD_REF" == "null" ]]; then
+  echo "unable to resolve PR head ref for #$PR_NUMBER" >&2
+  exit 1
+fi
+
+if [[ -z "$BASE_REF" || "$BASE_REF" == "null" ]]; then
+  echo "unable to resolve PR base ref for #$PR_NUMBER" >&2
+  exit 1
+fi
+
+if [[ -z "$HEAD_SHA" || "$HEAD_SHA" == "null" ]]; then
+  HEAD_SHA="unknown"
+fi
+
+if [[ -z "$BASE_SHA" || "$BASE_SHA" == "null" ]]; then
+  BASE_SHA="unknown"
+fi
+
+WORK_BRANCH="niuma-gate-$PR_NUMBER"
+MERGE_REF_SOURCE=""
+MERGE_SHA=""
+
+log "baseline=merge-result"
+
+# 优先使用 GitHub 的 merge ref，确保 gate 在 PR 合并结果基线上执行。
+if git fetch origin "pull/${PR_NUMBER}/merge"; then
+  MERGE_SHA=$(git rev-parse FETCH_HEAD)
+  git checkout -B "$WORK_BRANCH" "$MERGE_SHA"
+  MERGE_REF_SOURCE="github-merge-ref"
+else
+  # merge ref 不可用时，回退到本地 base+head 临时合并。
+  log "merge ref unavailable, fallback to local merge"
+  git fetch origin "$BASE_REF"
+  git fetch origin "$HEAD_REF"
+  git checkout -B "$WORK_BRANCH" "origin/$BASE_REF"
+
+  set +e
+  MERGE_OUTPUT=$(git -c user.name='niuma-gate' -c user.email='niuma-gate@local' merge --no-ff --no-edit "origin/$HEAD_REF" 2>&1)
+  MERGE_STATUS=$?
+  set -e
+
+  if [[ $MERGE_STATUS -ne 0 ]]; then
+    CONFLICT_FILES=$(git diff --name-only --diff-filter=U || true)
+    echo "CONFLICT: failed to merge origin/$HEAD_REF into origin/$BASE_REF" >&2
+
+    if [[ -n "$CONFLICT_FILES" ]]; then
+      echo "CONFLICT: files:" >&2
+      while IFS= read -r file; do
+        [[ -z "$file" ]] && continue
+        echo "CONFLICT: $file" >&2
+      done <<< "$CONFLICT_FILES"
+    fi
+
+    MERGE_SUMMARY=$(printf '%s\n' "$MERGE_OUTPUT" | grep -E 'CONFLICT|Automatic merge failed|^error:' | head -n 20 || true)
+    if [[ -z "$MERGE_SUMMARY" ]]; then
+      MERGE_SUMMARY=$(printf '%s\n' "$MERGE_OUTPUT" | tail -n 20)
+    fi
+
+    while IFS= read -r line; do
+      [[ -z "$line" ]] && continue
+      echo "CONFLICT: $line" >&2
+    done <<< "$MERGE_SUMMARY"
+
+    git merge --abort >/dev/null 2>&1 || true
+    exit 1
+  fi
+
+  MERGE_SHA=$(git rev-parse HEAD)
+  MERGE_REF_SOURCE="local-merge"
+fi
+
+log "merge_ref_source=$MERGE_REF_SOURCE"
+log "base_sha=$BASE_SHA"
+log "head_sha=$HEAD_SHA"
+if [[ -n "$MERGE_SHA" ]]; then
+  log "merge_sha=$MERGE_SHA"
+fi
+
 # Niuma 集成 gate：统一执行编译与测试。
 export MIX_ENV="test"
 

--- a/.github/scripts/niuma-test-gate.sh
+++ b/.github/scripts/niuma-test-gate.sh
@@ -149,9 +149,7 @@ cleanup_dependency_artifacts() {
     _build/test/lib/*/.mix
 }
 
-# 首次尝试前先清理一次，避免 runner 缓存里的半拉取状态影响首轮结果。
-cleanup_dependency_artifacts
-
+# 首轮优先复用缓存，失败后再清理半拉取状态并重试，避免每次都触发全量网络拉取。
 for attempt in $(seq 1 "$max_attempts"); do
   log "deps.get attempt=${attempt}/${max_attempts} timeout=${deps_get_timeout_seconds}s"
   if command -v timeout >/dev/null 2>&1; then

--- a/.github/scripts/niuma-test-gate.sh
+++ b/.github/scripts/niuma-test-gate.sh
@@ -138,10 +138,17 @@ deps_get_ok=0
 max_attempts=3
 deps_get_timeout_seconds=600
 
-# 仅清理图标相关 git 依赖残留，避免误删全部 deps 导致重试成本过高。
-cleanup_heroicons_artifacts() {
-  rm -rf deps/heroicons _build/test/lib/heroicons
+# 仅清理图标相关依赖残留，兼容 heroicons 与 heroicons_css 两种来源。
+cleanup_icon_artifacts() {
+  rm -rf \
+    deps/heroicons \
+    deps/heroicons_css \
+    _build/test/lib/heroicons \
+    _build/test/lib/heroicons_css
 }
+
+# 首次尝试前先清理一次，避免 runner 缓存里的半拉取状态影响首轮结果。
+cleanup_icon_artifacts
 
 for attempt in $(seq 1 "$max_attempts"); do
   log "deps.get attempt=${attempt}/${max_attempts} timeout=${deps_get_timeout_seconds}s"
@@ -170,8 +177,8 @@ for attempt in $(seq 1 "$max_attempts"); do
 
   if [ "$attempt" -lt "$max_attempts" ]; then
     sleep_seconds=$((attempt * 3))
-    echo "deps.get failed on attempt ${attempt}/${max_attempts}; cleaning heroicons artifacts and retrying in ${sleep_seconds}s..."
-    cleanup_heroicons_artifacts
+    echo "deps.get failed on attempt ${attempt}/${max_attempts}; cleaning icon artifacts and retrying in ${sleep_seconds}s..."
+    cleanup_icon_artifacts
     sleep "$sleep_seconds"
   fi
 done

--- a/.github/scripts/niuma-test-gate.sh
+++ b/.github/scripts/niuma-test-gate.sh
@@ -4,18 +4,42 @@ set -euo pipefail
 # Niuma 集成 gate：统一执行编译与测试。
 export MIX_ENV="test"
 
+# 仅在命令失败时打印尾部日志，避免 gate 截断后丢失真正报错。
+run_with_log_tail() {
+  local log_file
+  local status
+
+  log_file="$(mktemp)"
+  if "$@" >"$log_file" 2>&1; then
+    rm -f "$log_file"
+    return 0
+  fi
+
+  status=$?
+  echo "command failed: $*"
+  echo "----- last 120 lines -----"
+  tail -n 120 "$log_file"
+  echo "--------------------------"
+  rm -f "$log_file"
+  return "$status"
+}
+
 # 锁定依赖解析范围与 lock 文件，避免 gate 受环境漂移影响。
-# 网络瞬时抖动时做一次轻量重试，避免依赖下载偶发失败直接打断 gate。
+# 网络瞬时抖动时做重试；重试前清理可能的半拉取状态，避免污染后续尝试。
 deps_get_ok=0
-for attempt in 1 2; do
-  if mix deps.get --only test --check-locked; then
+max_attempts=3
+
+for attempt in $(seq 1 "$max_attempts"); do
+  if run_with_log_tail mix deps.get --only test --check-locked; then
     deps_get_ok=1
     break
   fi
 
-  if [ "$attempt" -lt 2 ]; then
-    echo "deps.get failed on attempt ${attempt}, retrying in 3s..."
-    sleep 3
+  if [ "$attempt" -lt "$max_attempts" ]; then
+    sleep_seconds=$((attempt * 3))
+    echo "deps.get failed on attempt ${attempt}/${max_attempts}; cleaning deps and retrying in ${sleep_seconds}s..."
+    rm -rf deps _build/test
+    sleep "$sleep_seconds"
   fi
 done
 
@@ -24,5 +48,5 @@ if [ "$deps_get_ok" -ne 1 ]; then
   exit 1
 fi
 
-mix compile --warnings-as-errors
-mix test
+run_with_log_tail mix compile --warnings-as-errors
+run_with_log_tail mix test

--- a/.github/scripts/niuma-test-gate.sh
+++ b/.github/scripts/niuma-test-gate.sh
@@ -136,12 +136,13 @@ run_with_log_tail() {
 # 网络瞬时抖动时做重试；重试前清理可能的半拉取状态，避免污染后续尝试。
 deps_get_ok=0
 max_attempts=3
-deps_get_timeout_seconds=180
+deps_get_timeout_seconds=600
 
 # 清理历史遗留目录，避免旧的 git 依赖状态污染本次解析。
 rm -rf deps/heroicons _build/test/lib/heroicons
 
 for attempt in $(seq 1 "$max_attempts"); do
+  log "deps.get attempt=${attempt}/${max_attempts} timeout=${deps_get_timeout_seconds}s"
   if command -v timeout >/dev/null 2>&1; then
     if run_with_log_tail timeout --signal=TERM --kill-after=30 "${deps_get_timeout_seconds}" \
       mix deps.get --only test --check-locked; then

--- a/.github/scripts/niuma-test-gate.sh
+++ b/.github/scripts/niuma-test-gate.sh
@@ -138,17 +138,19 @@ deps_get_ok=0
 max_attempts=3
 deps_get_timeout_seconds=600
 
-# 仅清理图标相关依赖残留，兼容 heroicons 与 heroicons_css 两种来源。
-cleanup_icon_artifacts() {
+# 清理依赖目录与 Mix 清单缓存，避免 runner 复用旧依赖解析状态。
+cleanup_dependency_artifacts() {
   rm -rf \
     deps/heroicons \
     deps/heroicons_css \
+    deps/.mix \
     _build/test/lib/heroicons \
-    _build/test/lib/heroicons_css
+    _build/test/lib/heroicons_css \
+    _build/test/lib/*/.mix
 }
 
 # 首次尝试前先清理一次，避免 runner 缓存里的半拉取状态影响首轮结果。
-cleanup_icon_artifacts
+cleanup_dependency_artifacts
 
 for attempt in $(seq 1 "$max_attempts"); do
   log "deps.get attempt=${attempt}/${max_attempts} timeout=${deps_get_timeout_seconds}s"
@@ -177,8 +179,8 @@ for attempt in $(seq 1 "$max_attempts"); do
 
   if [ "$attempt" -lt "$max_attempts" ]; then
     sleep_seconds=$((attempt * 3))
-    echo "deps.get failed on attempt ${attempt}/${max_attempts}; cleaning icon artifacts and retrying in ${sleep_seconds}s..."
-    cleanup_icon_artifacts
+    echo "deps.get failed on attempt ${attempt}/${max_attempts}; cleaning dependency artifacts and retrying in ${sleep_seconds}s..."
+    cleanup_dependency_artifacts
     sleep "$sleep_seconds"
   fi
 done

--- a/.github/scripts/niuma-test-gate.sh
+++ b/.github/scripts/niuma-test-gate.sh
@@ -5,6 +5,24 @@ set -euo pipefail
 export MIX_ENV="test"
 
 # 锁定依赖解析范围与 lock 文件，避免 gate 受环境漂移影响。
-mix deps.get --only test --check-locked
+# 网络瞬时抖动时做一次轻量重试，避免依赖下载偶发失败直接打断 gate。
+deps_get_ok=0
+for attempt in 1 2; do
+  if mix deps.get --only test --check-locked; then
+    deps_get_ok=1
+    break
+  fi
+
+  if [ "$attempt" -lt 2 ]; then
+    echo "deps.get failed on attempt ${attempt}, retrying in 3s..."
+    sleep 3
+  fi
+done
+
+if [ "$deps_get_ok" -ne 1 ]; then
+  echo "deps.get failed after retries"
+  exit 1
+fi
+
 mix compile --warnings-as-errors
 mix test

--- a/.github/scripts/niuma-test-gate.sh
+++ b/.github/scripts/niuma-test-gate.sh
@@ -138,8 +138,10 @@ deps_get_ok=0
 max_attempts=3
 deps_get_timeout_seconds=600
 
-# 清理历史遗留目录，避免旧的 git 依赖状态污染本次解析。
-rm -rf deps/heroicons _build/test/lib/heroicons
+# 仅清理图标相关 git 依赖残留，避免误删全部 deps 导致重试成本过高。
+cleanup_heroicons_artifacts() {
+  rm -rf deps/heroicons _build/test/lib/heroicons
+}
 
 for attempt in $(seq 1 "$max_attempts"); do
   log "deps.get attempt=${attempt}/${max_attempts} timeout=${deps_get_timeout_seconds}s"
@@ -168,8 +170,8 @@ for attempt in $(seq 1 "$max_attempts"); do
 
   if [ "$attempt" -lt "$max_attempts" ]; then
     sleep_seconds=$((attempt * 3))
-    echo "deps.get failed on attempt ${attempt}/${max_attempts}; cleaning deps and retrying in ${sleep_seconds}s..."
-    rm -rf deps _build/test
+    echo "deps.get failed on attempt ${attempt}/${max_attempts}; cleaning heroicons artifacts and retrying in ${sleep_seconds}s..."
+    cleanup_heroicons_artifacts
     sleep "$sleep_seconds"
   fi
 done

--- a/lib/men/gateway/event_bus.ex
+++ b/lib/men/gateway/event_bus.ex
@@ -4,6 +4,14 @@ defmodule Men.Gateway.EventBus do
   """
 
   @default_topic "gateway_events"
+  @schedule_event_type "task_schedule_triggered"
+  @schedule_required_fields [
+    :schedule_id,
+    :fire_time,
+    :idempotency_key,
+    :schedule_type,
+    :triggered_at
+  ]
 
   @spec publish(String.t(), map()) :: :ok
   def publish(topic \\ @default_topic, payload) when is_binary(topic) and is_map(payload) do
@@ -16,4 +24,92 @@ defmodule Men.Gateway.EventBus do
   def subscribe(topic \\ @default_topic) when is_binary(topic) do
     Phoenix.PubSub.subscribe(Men.PubSub, topic)
   end
+
+  @spec publish_schedule_trigger(String.t(), map()) :: :ok
+  def publish_schedule_trigger(topic \\ @default_topic, attrs)
+      when is_binary(topic) and is_map(attrs) do
+    payload = %{
+      type: @schedule_event_type,
+      schedule_id: fetch_text(attrs, :schedule_id, "unknown_schedule"),
+      fire_time: fetch_utc_iso8601(attrs, :fire_time),
+      idempotency_key: fetch_text(attrs, :idempotency_key, "missing_idempotency_key"),
+      schedule_type: fetch_text(attrs, :schedule_type, "unknown"),
+      triggered_at: fetch_utc_iso8601(attrs, :triggered_at),
+      metadata: build_schedule_metadata(attrs)
+    }
+
+    publish(topic, payload)
+  end
+
+  defp build_schedule_metadata(attrs) do
+    base_metadata =
+      case fetch_value(attrs, :metadata) do
+        %{} = metadata -> metadata
+        _ -> %{}
+      end
+
+    extra_metadata =
+      Enum.reduce(attrs, %{}, fn {key, value}, acc ->
+        normalized_key = normalize_meta_key(key)
+
+        if normalized_key in schedule_reserved_keys() do
+          acc
+        else
+          Map.put(acc, normalized_key, value)
+        end
+      end)
+
+    Map.merge(base_metadata, extra_metadata)
+  end
+
+  defp schedule_reserved_keys do
+    Enum.map(@schedule_required_fields, &Atom.to_string/1) ++ ["metadata"]
+  end
+
+  defp fetch_text(attrs, key, fallback) do
+    case fetch_value(attrs, key) do
+      value when is_binary(value) and value != "" -> value
+      value when is_atom(value) -> Atom.to_string(value)
+      _ -> fallback
+    end
+  end
+
+  defp fetch_utc_iso8601(attrs, key) do
+    value = fetch_value(attrs, key)
+    now = DateTime.utc_now()
+
+    cond do
+      is_struct(value, DateTime) ->
+        value
+        |> DateTime.shift_zone!("Etc/UTC")
+        |> DateTime.to_iso8601()
+
+      is_binary(value) ->
+        case DateTime.from_iso8601(value) do
+          {:ok, datetime, _offset} ->
+            datetime
+            |> DateTime.shift_zone!("Etc/UTC")
+            |> DateTime.to_iso8601()
+
+          _ ->
+            DateTime.to_iso8601(now)
+        end
+
+      is_integer(value) ->
+        value
+        |> DateTime.from_unix!(:millisecond)
+        |> DateTime.to_iso8601()
+
+      true ->
+        DateTime.to_iso8601(now)
+    end
+  end
+
+  defp fetch_value(attrs, key) do
+    Map.get(attrs, key) || Map.get(attrs, Atom.to_string(key))
+  end
+
+  defp normalize_meta_key(key) when is_atom(key), do: Atom.to_string(key)
+  defp normalize_meta_key(key) when is_binary(key), do: key
+  defp normalize_meta_key(key), do: inspect(key)
 end

--- a/lib/men/gateway/task_dispatcher.ex
+++ b/lib/men/gateway/task_dispatcher.ex
@@ -1,0 +1,339 @@
+defmodule Men.Gateway.TaskDispatcher do
+  @moduledoc """
+  Gateway 调度投递器：负责触发事件封装、去重、并发控制与背压。
+  """
+
+  use GenServer
+
+  require Logger
+
+  alias Men.Gateway.EventBus
+
+  @default_topic "gateway_events"
+  @default_dedup_ttl_ms :timer.minutes(5)
+  @default_max_concurrency 100
+
+  @type dispatch_request :: %{
+          required(:schedule_id) => binary(),
+          optional(:schedule_type) => atom() | binary(),
+          optional(:fire_time) => DateTime.t() | binary() | integer(),
+          optional(:idempotency_key) => binary(),
+          optional(:metadata) => map()
+        }
+
+  @type state :: %{
+          event_bus_topic: binary(),
+          max_concurrency: pos_integer(),
+          dedup_ttl_ms: pos_integer(),
+          inflight: non_neg_integer(),
+          recent_keys: %{optional(binary()) => non_neg_integer()},
+          publish_fun: (binary(), map() -> :ok | term()),
+          clock: (-> DateTime.t()),
+          dropped_count: non_neg_integer(),
+          dispatched_count: non_neg_integer(),
+          duplicate_count: non_neg_integer()
+        }
+
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(opts \\ []) do
+    name = Keyword.get(opts, :name, __MODULE__)
+    GenServer.start_link(__MODULE__, opts, name: name)
+  end
+
+  @spec dispatch(GenServer.server(), dispatch_request()) :: :ok
+  def dispatch(server \\ __MODULE__, request) when is_map(request) do
+    GenServer.cast(server, {:dispatch, request})
+  end
+
+  @spec stats(GenServer.server()) :: map()
+  def stats(server \\ __MODULE__) do
+    GenServer.call(server, :stats)
+  end
+
+  @impl true
+  def init(opts) do
+    config = Application.get_env(:men, __MODULE__, [])
+
+    state = %{
+      event_bus_topic: event_bus_topic(opts, config),
+      max_concurrency:
+        opts
+        |> Keyword.get(
+          :max_concurrency,
+          Keyword.get(config, :max_concurrency, @default_max_concurrency)
+        )
+        |> normalize_positive_integer(@default_max_concurrency),
+      dedup_ttl_ms:
+        opts
+        |> Keyword.get(:dedup_ttl_ms, Keyword.get(config, :dedup_ttl_ms, @default_dedup_ttl_ms))
+        |> normalize_positive_integer(@default_dedup_ttl_ms),
+      inflight: 0,
+      recent_keys: %{},
+      publish_fun:
+        Keyword.get(
+          opts,
+          :publish_fun,
+          Keyword.get(config, :publish_fun, &EventBus.publish_schedule_trigger/2)
+        ),
+      clock: Keyword.get(opts, :clock, Keyword.get(config, :clock, &DateTime.utc_now/0)),
+      dropped_count: 0,
+      dispatched_count: 0,
+      duplicate_count: 0
+    }
+
+    {:ok, state}
+  end
+
+  @impl true
+  def handle_cast({:dispatch, request}, state) do
+    now = now_utc(state.clock)
+    now_ms = DateTime.to_unix(now, :millisecond)
+    state = prune_recent_keys(state, now_ms)
+
+    case normalize_request(request, now) do
+      {:ok, normalized_request} ->
+        {:noreply, maybe_dispatch(normalized_request, now, now_ms, state)}
+
+      {:error, reason} ->
+        Logger.warning("task dispatch ignored: #{inspect(reason)}")
+        emit_telemetry(:invalid, %{reason: inspect(reason)})
+        {:noreply, state}
+    end
+  end
+
+  @impl true
+  def handle_call(:stats, _from, state) do
+    stats = %{
+      inflight: state.inflight,
+      dedup_size: map_size(state.recent_keys),
+      dropped_count: state.dropped_count,
+      dispatched_count: state.dispatched_count,
+      duplicate_count: state.duplicate_count,
+      max_concurrency: state.max_concurrency
+    }
+
+    {:reply, stats, state}
+  end
+
+  @impl true
+  def handle_info({:dispatch_done, idempotency_key, publish_result}, state)
+      when is_binary(idempotency_key) do
+    next_state = %{state | inflight: max(state.inflight - 1, 0)}
+
+    case publish_result do
+      :ok ->
+        emit_telemetry(:published, %{idempotency_key: idempotency_key})
+
+      other ->
+        Logger.warning("task dispatch publish returned non-ok: #{inspect(other)}")
+
+        emit_telemetry(:publish_failed, %{
+          idempotency_key: idempotency_key,
+          reason: inspect(other)
+        })
+    end
+
+    {:noreply, next_state}
+  end
+
+  def handle_info(_, state), do: {:noreply, state}
+
+  # 在独立任务里发布事件，避免阻塞 DispatchServer 主流程。
+  defp maybe_dispatch(request, now, now_ms, state) do
+    idempotency_key = request.idempotency_key
+
+    cond do
+      Map.has_key?(state.recent_keys, idempotency_key) ->
+        emit_telemetry(:duplicate, %{
+          idempotency_key: idempotency_key,
+          schedule_id: request.schedule_id
+        })
+
+        %{state | duplicate_count: state.duplicate_count + 1}
+
+      state.inflight >= state.max_concurrency ->
+        Logger.warning(
+          "task dispatch dropped by backpressure: schedule_id=#{request.schedule_id} inflight=#{state.inflight} max=#{state.max_concurrency}"
+        )
+
+        emit_telemetry(:dropped, %{schedule_id: request.schedule_id, inflight: state.inflight})
+        %{state | dropped_count: state.dropped_count + 1}
+
+      true ->
+        event_payload = %{
+          schedule_id: request.schedule_id,
+          fire_time: DateTime.to_iso8601(request.fire_time),
+          idempotency_key: idempotency_key,
+          schedule_type: request.schedule_type,
+          triggered_at: DateTime.to_iso8601(now),
+          metadata: request.metadata
+        }
+
+        parent = self()
+        publish_fun = state.publish_fun
+        event_bus_topic = state.event_bus_topic
+
+        Task.start(fn ->
+          publish_result =
+            try do
+              publish_fun.(event_bus_topic, event_payload)
+            rescue
+              error ->
+                {:error, error}
+            end
+
+          send(parent, {:dispatch_done, idempotency_key, publish_result})
+        end)
+
+        emit_telemetry(:accepted, %{
+          schedule_id: request.schedule_id,
+          inflight: state.inflight + 1
+        })
+
+        %{
+          state
+          | inflight: state.inflight + 1,
+            recent_keys: Map.put(state.recent_keys, idempotency_key, now_ms),
+            dispatched_count: state.dispatched_count + 1
+        }
+    end
+  end
+
+  defp normalize_request(request, now) when is_map(request) do
+    with {:ok, schedule_id} <- normalize_schedule_id(request),
+         {:ok, fire_time} <- normalize_fire_time(fetch_value(request, :fire_time), now) do
+      schedule_type = normalize_schedule_type(fetch_value(request, :schedule_type))
+      fire_time_iso = DateTime.to_iso8601(fire_time)
+
+      {:ok,
+       %{
+         schedule_id: schedule_id,
+         schedule_type: schedule_type,
+         fire_time: fire_time,
+         idempotency_key:
+           normalize_idempotency_key(
+             fetch_value(request, :idempotency_key),
+             schedule_id,
+             fire_time_iso
+           ),
+         metadata: normalize_metadata(request)
+       }}
+    end
+  end
+
+  defp normalize_request(_, _now), do: {:error, :invalid_request}
+
+  defp normalize_schedule_id(request) do
+    case fetch_value(request, :schedule_id) do
+      schedule_id when is_binary(schedule_id) and schedule_id != "" -> {:ok, schedule_id}
+      _ -> {:error, :invalid_schedule_id}
+    end
+  end
+
+  defp normalize_fire_time(nil, now), do: {:ok, now}
+
+  defp normalize_fire_time(%DateTime{} = fire_time, _now),
+    do: {:ok, DateTime.shift_zone!(fire_time, "Etc/UTC")}
+
+  defp normalize_fire_time(fire_time, _now) when is_binary(fire_time) do
+    case DateTime.from_iso8601(fire_time) do
+      {:ok, datetime, _offset} -> {:ok, DateTime.shift_zone!(datetime, "Etc/UTC")}
+      _ -> {:error, :invalid_fire_time}
+    end
+  end
+
+  defp normalize_fire_time(fire_time, _now) when is_integer(fire_time) do
+    {:ok, DateTime.from_unix!(fire_time, :millisecond)}
+  end
+
+  defp normalize_fire_time(_, _now), do: {:error, :invalid_fire_time}
+
+  defp normalize_schedule_type(type) when type in [:at, :cron], do: Atom.to_string(type)
+
+  defp normalize_schedule_type(type) when is_binary(type) do
+    trimmed = String.trim(type)
+
+    if trimmed in ["at", "cron"], do: trimmed, else: "unknown"
+  end
+
+  defp normalize_schedule_type(_), do: "unknown"
+
+  defp normalize_idempotency_key(value, _schedule_id, _fire_time_iso)
+       when is_binary(value) and value != "",
+       do: value
+
+  defp normalize_idempotency_key(_value, schedule_id, fire_time_iso),
+    do: schedule_id <> ":" <> fire_time_iso
+
+  defp normalize_metadata(request) do
+    metadata =
+      case fetch_value(request, :metadata) do
+        %{} = value -> value
+        _ -> %{}
+      end
+
+    reserved = ["schedule_id", "schedule_type", "fire_time", "idempotency_key", "metadata"]
+
+    extension =
+      Enum.reduce(request, %{}, fn {key, value}, acc ->
+        normalized_key = normalize_meta_key(key)
+
+        if normalized_key in reserved do
+          acc
+        else
+          Map.put(acc, normalized_key, value)
+        end
+      end)
+
+    Map.merge(metadata, extension)
+  end
+
+  defp normalize_meta_key(key) when is_atom(key), do: Atom.to_string(key)
+  defp normalize_meta_key(key) when is_binary(key), do: key
+  defp normalize_meta_key(key), do: inspect(key)
+
+  defp prune_recent_keys(state, now_ms) do
+    threshold = now_ms - state.dedup_ttl_ms
+
+    recent_keys =
+      Enum.reduce(state.recent_keys, %{}, fn {key, seen_ms}, acc ->
+        if seen_ms >= threshold, do: Map.put(acc, key, seen_ms), else: acc
+      end)
+
+    %{state | recent_keys: recent_keys}
+  end
+
+  defp normalize_positive_integer(value, _fallback)
+       when is_integer(value) and value > 0,
+       do: value
+
+  defp normalize_positive_integer(_value, fallback), do: fallback
+
+  defp fetch_value(request, key),
+    do: Map.get(request, key) || Map.get(request, Atom.to_string(key))
+
+  defp event_bus_topic(opts, config) do
+    dispatch_server_config = Application.get_env(:men, Men.Gateway.DispatchServer, [])
+
+    Keyword.get(
+      opts,
+      :event_bus_topic,
+      Keyword.get(
+        config,
+        :event_bus_topic,
+        Keyword.get(dispatch_server_config, :event_bus_topic, @default_topic)
+      )
+    )
+  end
+
+  defp now_utc(clock) do
+    clock.()
+    |> DateTime.shift_zone!("Etc/UTC")
+  end
+
+  defp emit_telemetry(event, metadata) do
+    :telemetry.execute([:men, :gateway, :task_dispatcher, event], %{count: 1}, metadata)
+  rescue
+    _ -> :ok
+  end
+end

--- a/lib/men/gateway/task_scheduler.ex
+++ b/lib/men/gateway/task_scheduler.ex
@@ -1,0 +1,449 @@
+defmodule Men.Gateway.TaskScheduler do
+  @moduledoc """
+  Gateway 调度扫描器：负责周期扫描到期任务，并投递到 TaskDispatcher。
+  """
+
+  use GenServer
+
+  require Logger
+
+  alias Men.Gateway.TaskDispatcher
+
+  @default_tick_interval_ms 1_000
+  @default_min_catchup_window_ms :timer.minutes(5)
+  @daily_cron "0 0 * * *"
+
+  @type schedule_type :: :at | :cron | :daily
+
+  @type state :: %{
+          dispatcher: GenServer.server(),
+          schedule_source: (-> list()),
+          tick_interval_ms: pos_integer(),
+          catchup_window_ms: pos_integer(),
+          clock: (-> DateTime.t()),
+          last_tick_at: DateTime.t() | nil,
+          auto_tick?: boolean(),
+          timer_ref: reference() | nil
+        }
+
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(opts \\ []) do
+    name = Keyword.get(opts, :name, __MODULE__)
+    GenServer.start_link(__MODULE__, opts, name: name)
+  end
+
+  @spec trigger_tick(GenServer.server()) :: {:ok, non_neg_integer()}
+  def trigger_tick(server \\ __MODULE__) do
+    GenServer.call(server, :trigger_tick)
+  end
+
+  @impl true
+  def init(opts) do
+    config = Application.get_env(:men, __MODULE__, [])
+    tick_interval_ms = build_tick_interval(opts, config)
+
+    state = %{
+      dispatcher:
+        Keyword.get(opts, :dispatcher, Keyword.get(config, :dispatcher, TaskDispatcher)),
+      schedule_source: schedule_source(opts, config),
+      tick_interval_ms: tick_interval_ms,
+      catchup_window_ms: build_catchup_window(opts, config, tick_interval_ms),
+      clock: Keyword.get(opts, :clock, Keyword.get(config, :clock, &DateTime.utc_now/0)),
+      last_tick_at: nil,
+      auto_tick?: Keyword.get(opts, :auto_tick?, Keyword.get(config, :auto_tick?, true)),
+      timer_ref: nil
+    }
+
+    if state.auto_tick? do
+      send(self(), :tick)
+    end
+
+    {:ok, state}
+  end
+
+  @impl true
+  def handle_call(:trigger_tick, _from, state) do
+    {dispatch_count, next_state} = run_tick(state)
+    {:reply, {:ok, dispatch_count}, next_state}
+  end
+
+  @impl true
+  def handle_info(:tick, state) do
+    {_dispatch_count, next_state} = run_tick(state)
+    {:noreply, schedule_next_tick(next_state)}
+  end
+
+  def handle_info(_, state), do: {:noreply, state}
+
+  defp run_tick(state) do
+    now = now_utc(state.clock)
+
+    window_start =
+      case state.last_tick_at do
+        %DateTime{} = last_tick_at -> last_tick_at
+        nil -> DateTime.add(now, -state.catchup_window_ms, :millisecond)
+      end
+
+    {dispatch_count, invalid_count} = dispatch_due_schedules(state, window_start, now)
+
+    emit_telemetry(:tick, %{
+      dispatch_count: dispatch_count,
+      invalid_count: invalid_count,
+      catchup_window_ms: state.catchup_window_ms
+    })
+
+    {dispatch_count, %{state | last_tick_at: now}}
+  end
+
+  defp dispatch_due_schedules(state, window_start, now) do
+    state.schedule_source.()
+    |> List.wrap()
+    |> Enum.reduce({0, 0}, fn schedule, {dispatch_count, invalid_count} ->
+      case normalize_schedule(schedule) do
+        {:ok, normalized_schedule} ->
+          fire_times = due_fire_times(normalized_schedule, window_start, now)
+
+          Enum.each(fire_times, fn fire_time ->
+            TaskDispatcher.dispatch(state.dispatcher, %{
+              schedule_id: normalized_schedule.schedule_id,
+              schedule_type: normalized_schedule.schedule_type,
+              fire_time: fire_time,
+              metadata: normalized_schedule.metadata
+            })
+          end)
+
+          {dispatch_count + length(fire_times), invalid_count}
+
+        {:error, reason} ->
+          Logger.warning("task scheduler ignored invalid schedule: #{inspect(reason)}")
+          {dispatch_count, invalid_count + 1}
+      end
+    end)
+  rescue
+    error ->
+      Logger.error("task scheduler scan failed: #{Exception.message(error)}")
+      {0, 1}
+  end
+
+  @spec normalize_schedule(map()) :: {:ok, map()} | {:error, term()}
+  def normalize_schedule(schedule) when is_map(schedule) do
+    with {:ok, schedule_id} <- normalize_schedule_id(schedule),
+         {:ok, schedule_type, cron_expr} <- normalize_schedule_type(schedule),
+         {:ok, next_run_at} <- normalize_next_run_at(schedule),
+         {:ok, parsed_cron} <- parse_schedule_cron(schedule_type, cron_expr) do
+      {:ok,
+       %{
+         schedule_id: schedule_id,
+         schedule_type: schedule_type,
+         next_run_at: next_run_at,
+         cron_expr: cron_expr,
+         parsed_cron: parsed_cron,
+         metadata: normalize_metadata(schedule)
+       }}
+    end
+  end
+
+  def normalize_schedule(_), do: {:error, :invalid_schedule}
+
+  @spec due_fire_times(map(), DateTime.t(), DateTime.t()) :: [DateTime.t()]
+  def due_fire_times(schedule, window_start, now)
+      when is_map(schedule) and is_struct(window_start, DateTime) and is_struct(now, DateTime) do
+    if DateTime.compare(schedule.next_run_at, now) == :gt do
+      []
+    else
+      case schedule.schedule_type do
+        :at ->
+          if in_window?(schedule.next_run_at, window_start, now),
+            do: [schedule.next_run_at],
+            else: []
+
+        :cron ->
+          cron_due_fire_times(schedule, window_start, now)
+      end
+    end
+  end
+
+  defp cron_due_fire_times(schedule, window_start, now) do
+    start_at = max_datetime(schedule.next_run_at, window_start)
+    candidate = ceil_to_minute(start_at)
+
+    do_collect_cron_fire_times(
+      candidate,
+      now,
+      schedule.next_run_at,
+      window_start,
+      schedule.parsed_cron,
+      []
+    )
+  end
+
+  defp do_collect_cron_fire_times(candidate, now, next_run_at, window_start, parsed_cron, acc) do
+    if DateTime.compare(candidate, now) == :gt do
+      Enum.reverse(acc)
+    else
+      matched? =
+        DateTime.compare(candidate, next_run_at) != :lt and
+          DateTime.compare(candidate, window_start) == :gt and
+          cron_match?(candidate, parsed_cron)
+
+      next_acc = if matched?, do: [candidate | acc], else: acc
+      next_candidate = DateTime.add(candidate, 60, :second)
+
+      do_collect_cron_fire_times(
+        next_candidate,
+        now,
+        next_run_at,
+        window_start,
+        parsed_cron,
+        next_acc
+      )
+    end
+  end
+
+  defp parse_schedule_cron(:at, _cron_expr), do: {:ok, nil}
+
+  defp parse_schedule_cron(:cron, cron_expr) when is_binary(cron_expr) do
+    parse_cron_expression(cron_expr)
+  end
+
+  defp parse_schedule_cron(:cron, _cron_expr), do: {:error, :invalid_cron_expression}
+
+  defp normalize_schedule_id(schedule) do
+    case fetch_value(schedule, :schedule_id) do
+      schedule_id when is_binary(schedule_id) and schedule_id != "" -> {:ok, schedule_id}
+      _ -> {:error, :invalid_schedule_id}
+    end
+  end
+
+  defp normalize_schedule_type(schedule) do
+    case fetch_value(schedule, :schedule_type) do
+      type when type in [:at, "at"] -> {:ok, :at, nil}
+      type when type in [:cron, "cron"] -> {:ok, :cron, fetch_cron_expr(schedule)}
+      type when type in [:daily, "daily"] -> {:ok, :cron, @daily_cron}
+      _ -> {:error, :invalid_schedule_type}
+    end
+  end
+
+  defp normalize_next_run_at(schedule) do
+    value = fetch_value(schedule, :next_run_at) || fetch_value(schedule, :scheduled_at)
+
+    case value do
+      %DateTime{} = datetime ->
+        {:ok, DateTime.shift_zone!(datetime, "Etc/UTC")}
+
+      value when is_binary(value) ->
+        case DateTime.from_iso8601(value) do
+          {:ok, datetime, _offset} -> {:ok, DateTime.shift_zone!(datetime, "Etc/UTC")}
+          _ -> {:error, :invalid_next_run_at}
+        end
+
+      value when is_integer(value) ->
+        {:ok, DateTime.from_unix!(value, :millisecond)}
+
+      _ ->
+        {:error, :invalid_next_run_at}
+    end
+  end
+
+  defp fetch_cron_expr(schedule) do
+    fetch_value(schedule, :cron) || fetch_value(schedule, :cron_expr) ||
+      fetch_value(schedule, :expression)
+  end
+
+  defp parse_cron_expression(expression) when is_binary(expression) do
+    parts = String.split(expression, ~r/\s+/, trim: true)
+
+    with [minute, hour, day_of_month, month, day_of_week] <- parts,
+         {:ok, minute_field} <- parse_cron_field(minute, 0, 59),
+         {:ok, hour_field} <- parse_cron_field(hour, 0, 23),
+         {:ok, day_of_month_field} <- parse_cron_field(day_of_month, 1, 31),
+         {:ok, month_field} <- parse_cron_field(month, 1, 12),
+         {:ok, day_of_week_field} <- parse_day_of_week_field(day_of_week) do
+      {:ok,
+       %{
+         minute: minute_field,
+         hour: hour_field,
+         day_of_month: day_of_month_field,
+         month: month_field,
+         day_of_week: day_of_week_field
+       }}
+    else
+      _ -> {:error, :invalid_cron_expression}
+    end
+  end
+
+  defp parse_cron_expression(_), do: {:error, :invalid_cron_expression}
+
+  defp parse_day_of_week_field("*"), do: {:ok, :any}
+
+  defp parse_day_of_week_field(value) when is_binary(value) do
+    value
+    |> String.split(",", trim: true)
+    |> Enum.reduce_while(MapSet.new(), fn token, acc ->
+      case Integer.parse(token) do
+        {int_value, ""} when int_value in 0..7 ->
+          normalized = if int_value == 7, do: 0, else: int_value
+          {:cont, MapSet.put(acc, normalized)}
+
+        _ ->
+          {:halt, :error}
+      end
+    end)
+    |> case do
+      :error -> {:error, :invalid_cron_expression}
+      set when map_size(set) > 0 -> {:ok, set}
+      _ -> {:error, :invalid_cron_expression}
+    end
+  end
+
+  defp parse_day_of_week_field(_), do: {:error, :invalid_cron_expression}
+
+  defp parse_cron_field("*", _min, _max), do: {:ok, :any}
+
+  defp parse_cron_field(value, min, max) when is_binary(value) do
+    value
+    |> String.split(",", trim: true)
+    |> Enum.reduce_while(MapSet.new(), fn token, acc ->
+      case Integer.parse(token) do
+        {int_value, ""} when int_value >= min and int_value <= max ->
+          {:cont, MapSet.put(acc, int_value)}
+
+        _ ->
+          {:halt, :error}
+      end
+    end)
+    |> case do
+      :error -> {:error, :invalid_cron_expression}
+      set when map_size(set) > 0 -> {:ok, set}
+      _ -> {:error, :invalid_cron_expression}
+    end
+  end
+
+  defp parse_cron_field(_value, _min, _max), do: {:error, :invalid_cron_expression}
+
+  defp cron_match?(datetime, parsed_cron) do
+    matches_field?(parsed_cron.minute, datetime.minute) and
+      matches_field?(parsed_cron.hour, datetime.hour) and
+      matches_field?(parsed_cron.day_of_month, datetime.day) and
+      matches_field?(parsed_cron.month, datetime.month) and
+      matches_field?(parsed_cron.day_of_week, day_of_week(datetime))
+  end
+
+  defp matches_field?(:any, _value), do: true
+  defp matches_field?(%MapSet{} = set, value), do: MapSet.member?(set, value)
+
+  defp day_of_week(datetime) do
+    case Date.day_of_week(DateTime.to_date(datetime)) do
+      7 -> 0
+      value -> value
+    end
+  end
+
+  defp ceil_to_minute(datetime) do
+    seconds = datetime.second
+    microsecond = elem(datetime.microsecond, 0)
+
+    floored = %{datetime | second: 0, microsecond: {0, 0}}
+
+    if seconds == 0 and microsecond == 0 do
+      floored
+    else
+      DateTime.add(floored, 60, :second)
+    end
+  end
+
+  defp in_window?(datetime, window_start, now) do
+    DateTime.compare(datetime, window_start) == :gt and
+      DateTime.compare(datetime, now) in [:lt, :eq]
+  end
+
+  defp max_datetime(left, right) do
+    case DateTime.compare(left, right) do
+      :lt -> right
+      _ -> left
+    end
+  end
+
+  defp normalize_metadata(schedule) do
+    case fetch_value(schedule, :metadata) do
+      %{} = metadata -> metadata
+      _ -> %{}
+    end
+  end
+
+  defp fetch_value(schedule, key),
+    do: Map.get(schedule, key) || Map.get(schedule, Atom.to_string(key))
+
+  defp build_tick_interval(opts, config) do
+    opts
+    |> Keyword.get(
+      :tick_interval_ms,
+      Keyword.get(config, :tick_interval_ms, @default_tick_interval_ms)
+    )
+    |> normalize_positive_integer(@default_tick_interval_ms)
+  end
+
+  defp build_catchup_window(opts, config, tick_interval_ms) do
+    configured_window =
+      opts
+      |> Keyword.get(:catchup_window_ms, Keyword.get(config, :catchup_window_ms))
+
+    computed_window = max(@default_min_catchup_window_ms, tick_interval_ms * 2)
+
+    case configured_window do
+      value when is_integer(value) and value > 0 -> max(value, computed_window)
+      _ -> computed_window
+    end
+  end
+
+  defp normalize_positive_integer(value, _fallback)
+       when is_integer(value) and value > 0,
+       do: value
+
+  defp normalize_positive_integer(_value, fallback), do: fallback
+
+  defp schedule_source(opts, config) do
+    source =
+      Keyword.get(opts, :schedule_source, Keyword.get(config, :schedule_source, fn -> [] end))
+
+    normalize_schedule_source(source)
+  end
+
+  defp normalize_schedule_source(source) when is_function(source, 0), do: source
+
+  defp normalize_schedule_source({module, function, args})
+       when is_atom(module) and is_atom(function) and is_list(args) do
+    fn -> apply(module, function, args) end
+  end
+
+  defp normalize_schedule_source(module) when is_atom(module) do
+    cond do
+      function_exported?(module, :list_schedules, 0) -> fn -> module.list_schedules() end
+      true -> fn -> [] end
+    end
+  end
+
+  defp normalize_schedule_source(source) when is_list(source), do: fn -> source end
+  defp normalize_schedule_source(_), do: fn -> [] end
+
+  defp schedule_next_tick(state) do
+    if state.auto_tick? do
+      if is_reference(state.timer_ref), do: Process.cancel_timer(state.timer_ref)
+      timer_ref = Process.send_after(self(), :tick, state.tick_interval_ms)
+      %{state | timer_ref: timer_ref}
+    else
+      state
+    end
+  end
+
+  defp now_utc(clock) do
+    clock.()
+    |> DateTime.shift_zone!("Etc/UTC")
+  end
+
+  defp emit_telemetry(event, metadata) do
+    :telemetry.execute([:men, :gateway, :task_scheduler, event], %{count: 1}, metadata)
+  rescue
+    _ -> :ok
+  end
+end

--- a/test/men/application_test.exs
+++ b/test/men/application_test.exs
@@ -1,0 +1,29 @@
+defmodule Men.ApplicationTest do
+  use ExUnit.Case, async: true
+
+  alias Men.Application, as: MenApplication
+
+  test "gateway_scheduler_enabled 为 false 时仅保留 webhook 主链路" do
+    assert [
+             {Men.Gateway.SessionCoordinator, []},
+             {Men.Gateway.DispatchServer, []}
+           ] == MenApplication.gateway_children(true, false)
+
+    assert [{Men.Gateway.DispatchServer, []}] == MenApplication.gateway_children(false, false)
+  end
+
+  test "gateway_scheduler_enabled 为 true 时挂载调度组件" do
+    assert [
+             {Men.Gateway.SessionCoordinator, []},
+             {Men.Gateway.DispatchServer, []},
+             {Men.Gateway.TaskDispatcher, []},
+             {Men.Gateway.TaskScheduler, []}
+           ] == MenApplication.gateway_children(true, true)
+
+    assert [
+             {Men.Gateway.DispatchServer, []},
+             {Men.Gateway.TaskDispatcher, []},
+             {Men.Gateway.TaskScheduler, []}
+           ] == MenApplication.gateway_children(false, true)
+  end
+end

--- a/test/men/gateway/event_bus_test.exs
+++ b/test/men/gateway/event_bus_test.exs
@@ -1,0 +1,31 @@
+defmodule Men.Gateway.EventBusTest do
+  use ExUnit.Case, async: true
+
+  alias Men.Gateway.EventBus
+
+  test "publish_schedule_trigger 冻结标准字段并透传 metadata 扩展" do
+    topic = "event_bus_test_#{System.unique_integer([:positive, :monotonic])}"
+    :ok = EventBus.subscribe(topic)
+
+    :ok =
+      EventBus.publish_schedule_trigger(topic, %{
+        schedule_id: "schedule-1",
+        fire_time: ~U[2026-02-25 12:00:00Z],
+        idempotency_key: "schedule-1:2026-02-25T12:00:00Z",
+        schedule_type: :at,
+        triggered_at: "2026-02-25T12:00:01Z",
+        metadata: %{trace_id: "trace-1"},
+        tenant: "default"
+      })
+
+    assert_receive {:gateway_event, payload}
+    assert payload.type == "task_schedule_triggered"
+    assert payload.schedule_id == "schedule-1"
+    assert payload.fire_time == "2026-02-25T12:00:00Z"
+    assert payload.idempotency_key == "schedule-1:2026-02-25T12:00:00Z"
+    assert payload.schedule_type == "at"
+    assert payload.triggered_at == "2026-02-25T12:00:01Z"
+    assert payload.metadata.trace_id == "trace-1"
+    assert payload.metadata["tenant"] == "default"
+  end
+end

--- a/test/men/gateway/task_dispatcher_test.exs
+++ b/test/men/gateway/task_dispatcher_test.exs
@@ -1,0 +1,135 @@
+defmodule Men.Gateway.TaskDispatcherTest do
+  use ExUnit.Case, async: false
+
+  alias Men.Gateway.DispatchServer
+  alias Men.Gateway.TaskDispatcher
+
+  defmodule FastBridge do
+    @behaviour Men.RuntimeBridge.Bridge
+
+    @impl true
+    def start_turn(prompt, _context) do
+      {:ok, %{text: "ok:" <> to_string(prompt), meta: %{source: :fast_bridge}}}
+    end
+  end
+
+  defmodule NoopEgress do
+    @behaviour Men.Channels.Egress.Adapter
+
+    @impl true
+    def send(_target, _message), do: :ok
+  end
+
+  test "同 schedule_id+fire_time 仅发布一次" do
+    topic = "task_dispatcher_dedup_#{System.unique_integer([:positive, :monotonic])}"
+    :ok = Men.Gateway.EventBus.subscribe(topic)
+
+    dispatcher =
+      start_supervised!(
+        {TaskDispatcher,
+         [
+           name: {:global, {__MODULE__, :dedup, self(), make_ref()}},
+           event_bus_topic: topic,
+           dedup_ttl_ms: :timer.minutes(5),
+           max_concurrency: 10
+         ]}
+      )
+
+    fire_time = ~U[2026-02-25 12:00:00Z]
+
+    :ok =
+      TaskDispatcher.dispatch(dispatcher, %{
+        schedule_id: "schedule-dedup-1",
+        schedule_type: :at,
+        fire_time: fire_time,
+        metadata: %{trace_id: "trace-dedup-1"}
+      })
+
+    :ok =
+      TaskDispatcher.dispatch(dispatcher, %{
+        schedule_id: "schedule-dedup-1",
+        schedule_type: :at,
+        fire_time: fire_time,
+        metadata: %{trace_id: "trace-dedup-1"}
+      })
+
+    assert_receive {:gateway_event, payload}
+    assert payload.schedule_id == "schedule-dedup-1"
+    assert payload.fire_time == "2026-02-25T12:00:00Z"
+    assert payload.idempotency_key == "schedule-dedup-1:2026-02-25T12:00:00Z"
+
+    refute_receive {:gateway_event, %{schedule_id: "schedule-dedup-1"}}
+
+    stats = TaskDispatcher.stats(dispatcher)
+    assert stats.dispatched_count == 1
+    assert stats.duplicate_count == 1
+  end
+
+  test "高并发到期任务触发时受并发上限与背压控制且不阻塞 DispatchServer" do
+    topic = "task_dispatcher_concurrency_#{System.unique_integer([:positive, :monotonic])}"
+    parent = self()
+
+    publish_fun = fn _topic, payload ->
+      send(parent, {:task_dispatch_published, payload.schedule_id})
+      Process.sleep(120)
+      :ok
+    end
+
+    dispatcher =
+      start_supervised!(
+        {TaskDispatcher,
+         [
+           name: {:global, {__MODULE__, :concurrency, self(), make_ref()}},
+           event_bus_topic: topic,
+           dedup_ttl_ms: :timer.minutes(5),
+           max_concurrency: 5,
+           publish_fun: publish_fun
+         ]}
+      )
+
+    fire_time = ~U[2026-02-25 12:00:00Z]
+
+    Enum.each(1..100, fn index ->
+      :ok =
+        TaskDispatcher.dispatch(dispatcher, %{
+          schedule_id: "schedule-concurrency-#{index}",
+          schedule_type: :at,
+          fire_time: fire_time,
+          metadata: %{batch: "load-test"}
+        })
+    end)
+
+    Process.sleep(40)
+
+    stats = TaskDispatcher.stats(dispatcher)
+    assert stats.inflight <= 5
+    assert stats.dropped_count >= 90
+
+    dispatch_server =
+      start_supervised!(
+        {DispatchServer,
+         [
+           name: {:global, {__MODULE__, :dispatch_server, self(), make_ref()}},
+           bridge_adapter: FastBridge,
+           egress_adapter: NoopEgress,
+           session_coordinator_enabled: false,
+           event_coordination_enabled: false,
+           wake_enabled: false
+         ]}
+      )
+
+    {cost_us, dispatch_result} =
+      :timer.tc(fn ->
+        DispatchServer.dispatch(dispatch_server, %{
+          request_id: "request-concurrency-1",
+          payload: "hello",
+          metadata: %{source: :test},
+          channel: "feishu",
+          user_id: "u100"
+        })
+      end)
+
+    assert {:ok, _result} = dispatch_result
+    assert cost_us < 400_000
+  end
+end

--- a/test/men/gateway/task_scheduler_test.exs
+++ b/test/men/gateway/task_scheduler_test.exs
@@ -1,0 +1,220 @@
+defmodule Men.Gateway.TaskSchedulerTest do
+  use ExUnit.Case, async: false
+
+  alias Men.Gateway.EventBus
+  alias Men.Gateway.TaskDispatcher
+  alias Men.Gateway.TaskScheduler
+
+  test "到期单次触发: at 任务到点仅投递一次" do
+    topic = "task_scheduler_at_#{System.unique_integer([:positive, :monotonic])}"
+    :ok = EventBus.subscribe(topic)
+
+    base_time = ~U[2026-02-25 12:00:00Z]
+    {:ok, clock} = Agent.start_link(fn -> DateTime.to_unix(base_time, :millisecond) end)
+    {:ok, schedules} = Agent.start_link(fn -> [] end)
+
+    dispatcher =
+      start_supervised!(
+        {TaskDispatcher,
+         [
+           name: {:global, {__MODULE__, :dispatcher_at, self(), make_ref()}},
+           event_bus_topic: topic,
+           max_concurrency: 100
+         ]}
+      )
+
+    scheduler =
+      start_supervised!(
+        {TaskScheduler,
+         [
+           name: {:global, {__MODULE__, :scheduler_at, self(), make_ref()}},
+           dispatcher: dispatcher,
+           auto_tick?: false,
+           tick_interval_ms: 1_000,
+           schedule_source: fn -> Agent.get(schedules, & &1) end,
+           clock: fn -> Agent.get(clock, &DateTime.from_unix!(&1, :millisecond)) end
+         ]}
+      )
+
+    Agent.update(schedules, fn _ ->
+      [
+        %{
+          schedule_id: "schedule-at-1",
+          schedule_type: :at,
+          next_run_at: DateTime.add(base_time, 10, :second),
+          metadata: %{source: "test_at"}
+        }
+      ]
+    end)
+
+    assert {:ok, 0} = TaskScheduler.trigger_tick(scheduler)
+
+    Agent.update(clock, fn _ ->
+      DateTime.to_unix(DateTime.add(base_time, 10, :second), :millisecond)
+    end)
+
+    assert {:ok, 1} = TaskScheduler.trigger_tick(scheduler)
+
+    assert_receive {:gateway_event, payload}
+    assert payload.schedule_id == "schedule-at-1"
+    assert payload.fire_time == "2026-02-25T12:00:10Z"
+    assert payload.idempotency_key == "schedule-at-1:2026-02-25T12:00:10Z"
+
+    Agent.update(clock, fn _ ->
+      DateTime.to_unix(DateTime.add(base_time, 11, :second), :millisecond)
+    end)
+
+    assert {:ok, 0} = TaskScheduler.trigger_tick(scheduler)
+    refute_receive {:gateway_event, %{schedule_id: "schedule-at-1"}}
+  end
+
+  test "Scheduler 异常退出后重启可补跑 catchup window 内遗漏任务" do
+    topic = "task_scheduler_restart_#{System.unique_integer([:positive, :monotonic])}"
+    :ok = EventBus.subscribe(topic)
+
+    base_time = ~U[2026-02-25 12:00:00Z]
+    {:ok, clock} = Agent.start_link(fn -> DateTime.to_unix(base_time, :millisecond) end)
+    {:ok, schedules} = Agent.start_link(fn -> [] end)
+
+    dispatcher_name = {:global, {__MODULE__, :dispatcher_restart, self(), make_ref()}}
+
+    start_supervised!(
+      {TaskDispatcher,
+       [
+         name: dispatcher_name,
+         event_bus_topic: topic,
+         max_concurrency: 100
+       ]}
+    )
+
+    Agent.update(schedules, fn _ ->
+      [
+        %{
+          schedule_id: "schedule-restart-1",
+          schedule_type: :at,
+          next_run_at: DateTime.add(base_time, 5, :second),
+          metadata: %{source: "test_restart"}
+        }
+      ]
+    end)
+
+    scheduler_name = {:global, {__MODULE__, :scheduler_restart, self(), make_ref()}}
+
+    supervisor =
+      start_supervised!(
+        {DynamicSupervisor,
+         strategy: :one_for_one,
+         name: {:global, {__MODULE__, :scheduler_supervisor, self(), make_ref()}}}
+      )
+
+    assert {:ok, _child_pid} =
+             DynamicSupervisor.start_child(
+               supervisor,
+               {TaskScheduler,
+                [
+                  name: scheduler_name,
+                  dispatcher: dispatcher_name,
+                  auto_tick?: false,
+                  tick_interval_ms: 1_000,
+                  schedule_source: fn -> Agent.get(schedules, & &1) end,
+                  clock: fn -> Agent.get(clock, &DateTime.from_unix!(&1, :millisecond)) end
+                ]}
+             )
+
+    old_pid = GenServer.whereis(scheduler_name)
+    assert is_pid(old_pid)
+    Process.exit(old_pid, :kill)
+
+    new_pid = wait_for_restarted_pid(scheduler_name, old_pid)
+    assert is_pid(new_pid)
+
+    Agent.update(clock, fn _ ->
+      DateTime.to_unix(DateTime.add(base_time, 7, :second), :millisecond)
+    end)
+
+    assert {:ok, 1} = TaskScheduler.trigger_tick(scheduler_name)
+
+    assert_receive {:gateway_event, payload}
+    assert payload.schedule_id == "schedule-restart-1"
+    assert payload.fire_time == "2026-02-25T12:00:05Z"
+  end
+
+  test "daily 语法糖归一化为 UTC cron 0 0 * * * 并按 cron 触发" do
+    topic = "task_scheduler_daily_#{System.unique_integer([:positive, :monotonic])}"
+    :ok = EventBus.subscribe(topic)
+
+    base_time = ~U[2026-02-25 00:00:30Z]
+    {:ok, clock} = Agent.start_link(fn -> DateTime.to_unix(base_time, :millisecond) end)
+    {:ok, schedules} = Agent.start_link(fn -> [] end)
+
+    dispatcher =
+      start_supervised!(
+        {TaskDispatcher,
+         [
+           name: {:global, {__MODULE__, :dispatcher_daily, self(), make_ref()}},
+           event_bus_topic: topic,
+           max_concurrency: 100
+         ]}
+      )
+
+    scheduler =
+      start_supervised!(
+        {TaskScheduler,
+         [
+           name: {:global, {__MODULE__, :scheduler_daily, self(), make_ref()}},
+           dispatcher: dispatcher,
+           auto_tick?: false,
+           tick_interval_ms: 1_000,
+           schedule_source: fn -> Agent.get(schedules, & &1) end,
+           clock: fn -> Agent.get(clock, &DateTime.from_unix!(&1, :millisecond)) end
+         ]}
+      )
+
+    Agent.update(schedules, fn _ ->
+      [
+        %{
+          schedule_id: "schedule-daily-1",
+          schedule_type: :daily,
+          next_run_at: ~U[2026-02-25 00:00:00Z],
+          metadata: %{source: "test_daily"}
+        }
+      ]
+    end)
+
+    assert {:ok, normalized} =
+             TaskScheduler.normalize_schedule(%{
+               schedule_id: "schedule-daily-normalize",
+               schedule_type: :daily,
+               next_run_at: ~U[2026-02-25 00:00:00Z]
+             })
+
+    assert normalized.schedule_type == :cron
+    assert normalized.cron_expr == "0 0 * * *"
+
+    assert {:ok, 1} = TaskScheduler.trigger_tick(scheduler)
+
+    assert_receive {:gateway_event, payload}
+    assert payload.schedule_id == "schedule-daily-1"
+    assert payload.fire_time == "2026-02-25T00:00:00Z"
+    assert payload.schedule_type == "cron"
+  end
+
+  defp wait_for_restarted_pid(name, old_pid, attempts \\ 20)
+
+  defp wait_for_restarted_pid(_name, _old_pid, 0), do: nil
+
+  defp wait_for_restarted_pid(name, old_pid, attempts) do
+    case GenServer.whereis(name) do
+      nil ->
+        Process.sleep(20)
+        wait_for_restarted_pid(name, old_pid, attempts - 1)
+
+      ^old_pid ->
+        Process.sleep(20)
+        wait_for_restarted_pid(name, old_pid, attempts - 1)
+
+      pid when is_pid(pid) ->
+        pid
+    end
+  end
+end


### PR DESCRIPTION
Closes #69

## Summary

## ✅ 最终方案：Gateway 单一调度 Owner 落地方案（TaskScheduler/TaskDispatcher）

### 实现方案

在 Gateway 层建立调度编排骨架，职责仅覆盖扫描/触发/投递，不引入 Lease/锁、不实现 TaskStore 持久化细节、不触达容器执行。具体实现为：1) 在 supervision tree 挂载 TaskDispatcher 与 TaskScheduler，并由 feature flag `gateway_scheduler_enabled` 控制启停（关闭后仅保留 webhook 主链路）；2) TaskScheduler 采用 GenServer 周期 tick，按 `next_run_at <= now` 扫描到期任务，重启后按 `catchup_window = max(5min, 2*tick_interval)` 补跑遗漏；支持 `schedule_type=at|cron`，`daily` 统一语法糖转换为 `cron: 0 0 * * *`（UTC）；3) TaskDispatcher 只做投递编排，不直接调用 runtime：为每次触发生成 `fire_time`，构造 `idempotency_key = schedule_id + fire_time`，先做内存滑窗（默认 5 分钟）尽力去重，再发布到 EventBus，由下游承担最终幂等；4) Dispatcher 增加并发上限（默认 100）和背压策略（超限 drop + telemetry/日志告警），保证 DispatchServer 主流程不被阻塞；5) EventBus 扩展并冻结最小调度事件字段：`schedule_id`、`fire_time`、`idempotency_key`、`schedule_type`、`triggered_at`，其余放 metadata 扩展。该方案直接满足单次触发唯一性、重启补跑、并发可控与可熔断回滚要求。

### 文件变更

| 路径 | 操作 | 描述 |
|------|------|------|
| `lib/men/application.ex` | modify | 接入 `Men.Gateway.TaskDispatcher` 与 `Men.Gateway.TaskScheduler` 到 supervision tree，读取并应用 `gateway_scheduler_enabled` 配置开关，关闭时不启动调度组件。 |
| `lib/men/gateway/task_scheduler.ex` | add | 新增 Scheduler GenServer：周期 tick、按 `next_run_at` 扫描、重启补跑窗口、`at|cron|daily` 编排入口（daily 转 cron UTC），并调用 Dispatcher 进行触发请求下发。 |
| `lib/men/gateway/task_dispatcher.ex` | add | 新增 Dispatcher：生成 `fire_time` 与 `idempotency_key`、内存滑窗尽力去重、并发上限与背压控制、将触发请求转为 EventBus 主链路事件。 |
| `lib/men/gateway/event_bus.ex` | modify | 扩展调度事件类型与标准 metadata 字段（`schedule_id`、`fire_time`、`idempotency_key`、`schedule_type`、`triggered_at`），保证可观测性与后续链路兼容。 |

### 测试场景

1. **到期单次触发**: 输入 `应用启动后注册 10 秒后到期任务` → 预期 `到期仅触发一次 dispatch，`schedule_id+fire_time` 唯一`
2. **Scheduler 重启补跑**: 输入 `Scheduler 进程异常退出后自动重启` → 预期 `恢复扫描并补跑遗漏任务，不丢失到期触发`
3. **高并发到期任务**: 输入 `100 个任务同一时刻到期` → 预期 `触发受并发上限控制，不阻塞 DispatchServer 主流程`
4. **调度熔断开关**: 输入 `将 `gateway_scheduler_enabled` 设为 false` → 预期 `调度组件不运行，仅 webhook 主链路可用`
5. **daily 语法糖归一化**: 输入 ``schedule_type=daily`` → 预期 `转换为 UTC cron `0 0 * * *` 并按 cron 流程触发`


---
*方案已定稿，即将开始实现。*
<!-- PLAN_FILES:[{"path":"lib/men/application.ex","action":"modify","description":"接入 `Men.Gateway.TaskDispatcher` 与 `Men.Gateway.TaskScheduler` 到 supervision tree，读取并应用 `gateway_scheduler_enabled` 配置开关，关闭时不启动调度组件。"},{"path":"lib/men/gateway/task_scheduler.ex","action":"add","description":"新增 Scheduler GenServer：周期 tick、按 `next_run_at` 扫描、重启补跑窗口、`at|cron|daily` 编排入口（daily 转 cron UTC），并调用 Dispatcher 进行触发请求下发。"},{"path":"lib/men/gateway/task_dispatcher.ex","action":"add","description":"新增 Dispatcher：生成 `fire_time` 与 `idempotency_key`、内存滑窗尽力去重、并发上限与背压控制、将触发请求转为 EventBus 主链路事件。"},{"path":"lib/men/gateway/event_bus.ex","action":"modify","description":"扩展调度事件类型与标准 metadata 字段（`schedule_id`、`fire_time`、`idempotency_key`、`schedule_type`、`triggered_at`），保证可观测性与后续链路兼容。"},{"path":".github/scripts/niuma-test-gate.sh","action":"modify","description":"自动同步：根据 PR 实际改动补齐（status=modified）"},{"path":"test/men/application_test.exs","action":"new","description":"自动同步：根据 PR 实际改动补齐（status=added）"},{"path":"test/men/gateway/event_bus_test.exs","action":"new","description":"自动同步：根据 PR 实际改动补齐（status=added）"},{"path":"test/men/gateway/task_dispatcher_test.exs","action":"new","description":"自动同步：根据 PR 实际改动补齐（status=added）"},{"path":"test/men/gateway/task_scheduler_test.exs","action":"new","description":"自动同步：根据 PR 实际改动补齐（status=added）"}] -->